### PR TITLE
03: nix-store: --tree and -R are mutually exclusive

### DIFF
--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -260,7 +260,7 @@
 
     <para>
       Same applies to environments of course. As an exercise run
-      <literal>nix-store -qR --tree ~/.nix-profile</literal>, see that the
+      <literal>nix-store -q --tree ~/.nix-profile</literal>, see that the
       first children are direct dependencies of the user environment:
       the installed derivations, and the manifest.nix.
     </para>

--- a/pills/03/nix-store-tree.txt
+++ b/pills/03/nix-store-tree.txt
@@ -1,2 +1,2 @@
-$ nix-store -qR --tree `which man`
+$ nix-store -q --tree `which man`
 [...]


### PR DESCRIPTION
In current NixOS 17.09,
Current version of `nix-store` command does not accept command as possible one:
```shell
$ nix-store -qR --tree $(command -s man)
error: query type ‘--tree’ conflicts with earlier flag
Try ‘nix-store --help’ for more information.
```

So, `--tree` and `-R` are mutually exclusive options. 
```shell
$ nix-store -q --tree (command -s nix-store)                                                                                                                                                   (1)
/nix/store/b8xy8bdxh1r5yjda332qrxj1vvvsy4fq-nix-1.11.15
+---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
+---/nix/store/gpbdiwg2mg21kppj12y019is5r0f8cgn-sqlite-3.20.0
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/gpbdiwg2mg21kppj12y019is5r0f8cgn-sqlite-3.20.0 [...]
+---/nix/store/vp8y0rh8rq7vikbbrpf28jfym79xq9z8-coreutils-8.28
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/icxr8r6g584a3rhzixjs4zwwscssjr4c-attr-2.4.47
|   |   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   |   +---/nix/store/icxr8r6g584a3rhzixjs4zwwscssjr4c-attr-2.4.47 [...]
|   +---/nix/store/47ba88rwcima20wkw3j6r9i5nf4yxjmy-acl-2.2.52
|   |   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   |   +---/nix/store/icxr8r6g584a3rhzixjs4zwwscssjr4c-attr-2.4.47 [...]
|   |   +---/nix/store/47ba88rwcima20wkw3j6r9i5nf4yxjmy-acl-2.2.52 [...]
|   +---/nix/store/vp8y0rh8rq7vikbbrpf28jfym79xq9z8-coreutils-8.28 [...]
+---/nix/store/sbmxzfdnnl99jdhfsx4wasbcx6v7r0a2-perl-5.24.2
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/vp8y0rh8rq7vikbbrpf28jfym79xq9z8-coreutils-8.28 [...]
|   +---/nix/store/sbmxzfdnnl99jdhfsx4wasbcx6v7r0a2-perl-5.24.2 [...]
+---/nix/store/i75adw8s20flph7wvhffma1is26llh2y-perl-DBI-1.636
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/sbmxzfdnnl99jdhfsx4wasbcx6v7r0a2-perl-5.24.2 [...]
|   +---/nix/store/i75adw8s20flph7wvhffma1is26llh2y-perl-DBI-1.636 [...]
+---/nix/store/4qsl6n0a51vb3b6w9ncppk7il62qchgy-perl-DBD-SQLite-1.50
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/gpbdiwg2mg21kppj12y019is5r0f8cgn-sqlite-3.20.0 [...]
|   +---/nix/store/i75adw8s20flph7wvhffma1is26llh2y-perl-DBI-1.636 [...]
|   +---/nix/store/4qsl6n0a51vb3b6w9ncppk7il62qchgy-perl-DBD-SQLite-1.50 [...]
+---/nix/store/9bmbvrlmcq58sw1z4q58iyfrsnbzy3db-libseccomp-2.3.2
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/9bmbvrlmcq58sw1z4q58iyfrsnbzy3db-libseccomp-2.3.2 [...]
+---/nix/store/ybajdccj1h5xssna16h6vv3qqda6m7l4-openssl-1.0.2l
|   +---/nix/store/xzx1bv1d7z4mgg6sg6ly0jx609qvka4x-glibc-2.25-49 [...]
|   +---/nix/store/ybajdccj1h5xssna16h6vv3qqda6m7l4-openssl-1.0.2l [...]
```

So `nix-store -q --tree (command -s nix-store)` is the right command.

Closes #9.