### PR TITLE
03: fix dead links uninstall/upgrade, change word

### DIFF
--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -172,8 +172,9 @@
 
     <para>
       You can of course also <link
-      xlink:href="http://nixos.org/nix/manual/#idm47361539520832">
-      delete and upgrade packages</link>.
+        xlink:href="https://nixos.org/nix/manual/#operation-uninstall">
+      uninstall</link> and <link
+      xlink:href="https://nixos.org/nix/manual/#operation-upgrade">upgrade</link> packages.
     </para>
   </section>
 


### PR DESCRIPTION
I changed the wording from "delete" to "uninstall" to match the official documentation. I also think uninstall makes more sense because of how nix manages package and dependencies.