### PR TITLE
A few small fixes to braces and filename placement

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -288,7 +288,7 @@
       Afterwards, we call the function with the empty set. We saw this already
       in <link linkend="functions-and-imports">the fifth pill</link>. To
       reiterate: <code>import &lt;nixpkgs> {}</code> is calling two functions,
-      not one. Reading it as <code>(import &lt;nixpkgs> {}</code> makes this
+      not one. Reading it as <code>(import &lt;nixpkgs>) {}</code> makes this
       clearer.
     </para>
     <para>

--- a/pills/07/c-program-derivation.xml
+++ b/pills/07/c-program-derivation.xml
@@ -1,5 +1,5 @@
 <screen xmlns="http://docbook.org/ns/docbook"><prompt>nix-repl> </prompt><userinput>:l &lt;nixpkgs></userinput>
-<prompt>nix-repl> </prompt><userinput>simple = derivation { name = "simple"; builder = "${bash}/bin/bash"; args = [ ./simple_builder.sh ]; gcc = gcc; coreutils = coreutils; src = ./simple.c; system = builtins.currentSystem;</userinput>
+<prompt>nix-repl> </prompt><userinput>simple = derivation { name = "simple"; builder = "${bash}/bin/bash"; args = [ ./simple_builder.sh ]; gcc = gcc; coreutils = coreutils; src = ./simple.c; system = builtins.currentSystem; }</userinput>
 <prompt>nix-repl> </prompt><userinput>:b simple</userinput>
 <computeroutput>this derivation produced the following outputs:
 

--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -38,7 +38,7 @@
     </para>
 
     <para>
-      Let's create a builder script for GNU hello world:
+      Let's create a builder script for GNU hello world, hello_builder.sh:
     </para>
 
     <screen><xi:include href="./08/hello-builder.txt" parse="text" /></screen>

--- a/pills/08/hello-builder.txt
+++ b/pills/08/hello-builder.txt
@@ -1,4 +1,3 @@
-hello_builder.sh
 export PATH="$gnutar/bin:$gcc/bin:$gnumake/bin:$coreutils/bin:$gawk/bin:$gzip/bin:$gnugrep/bin:$gnused/bin:$binutils/bin"
 tar -xzf $src
 cd hello-2.9


### PR DESCRIPTION
Add 2, missing closing braces/parens, and move script name out of script to the text above it.