### PR TITLE
Update GNU Hello version to 2.10

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -34,7 +34,7 @@
       <link xlink:href="http://www.gnu.org/software/hello/">GNU hello world</link>,
       despite its name, is a simple yet complete project using autotools.
       Fetch the latest tarball here:
-      <link xlink:href="http://ftp.gnu.org/gnu/hello/hello-2.9.tar.gz">http://ftp.gnu.org/gnu/hello/hello-2.9.tar.gz</link>.
+      <link xlink:href="http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz">http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz</link>.
     </para>
 
     <para>

--- a/pills/08/hello-builder.txt
+++ b/pills/08/hello-builder.txt
@@ -1,6 +1,6 @@
 export PATH="$gnutar/bin:$gcc/bin:$gnumake/bin:$coreutils/bin:$gawk/bin:$gzip/bin:$gnugrep/bin:$gnused/bin:$binutils/bin"
 tar -xzf $src
-cd hello-2.9
+cd hello-2.10
 ./configure --prefix=$out
 make
 make install

--- a/pills/08/hello-nix-rev-1.txt
+++ b/pills/08/hello-nix-rev-1.txt
@@ -4,6 +4,6 @@ derivation {
   builder = "${bash}/bin/bash";
   args = [ ./builder.sh ];
   buildInputs = [ gnutar gzip gnumake gcc binutils coreutils gawk gnused gnugrep ];
-  src = ./hello-2.9.tar.gz;
+  src = ./hello-2.10.tar.gz;
   system = builtins.currentSystem;
 }

--- a/pills/08/hello-nix-rev-2.txt
+++ b/pills/08/hello-nix-rev-2.txt
@@ -3,5 +3,5 @@ let
   mkDerivation = import ./autotools.nix pkgs;
 in mkDerivation {
   name = "hello";
-  src = ./hello-2.9.tar.gz;
+  src = ./hello-2.10.tar.gz;
 }

--- a/pills/08/hello-nix.txt
+++ b/pills/08/hello-nix.txt
@@ -4,6 +4,6 @@ derivation {
   builder = "${bash}/bin/bash";
   args = [ ./hello_builder.sh ];
   inherit gnutar gzip gnumake gcc binutils coreutils gawk gnused gnugrep;
-  src = ./hello-2.9.tar.gz;
+  src = ./hello-2.10.tar.gz;
   system = builtins.currentSystem;
 }

--- a/pills/09/instantiate.txt
+++ b/pills/09/instantiate.txt
@@ -1,7 +1,7 @@
 $ nix-instantiate hello.nix
 /nix/store/z77vn965a59irqnrrjvbspiyl2rph0jp-hello.drv
 $ nix-store -q --references /nix/store/z77vn965a59irqnrrjvbspiyl2rph0jp-hello.drv
-/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.9.tar.gz
+/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.10.tar.gz
 /nix/store/1zcs1y4n27lqs0gw4v038i303pb89rw6-coreutils-8.21.drv
 /nix/store/2h4b30hlfw4fhqx10wwi71mpim4wr877-gnused-4.2.2.drv
 /nix/store/39bgdjissw9gyi4y5j9wanf4dbjpbl07-gnutar-1.27.1.drv

--- a/pills/10-developing-with-nix-shell.xml
+++ b/pills/10-developing-with-nix-shell.xml
@@ -75,13 +75,13 @@
       </listitem>
       <listitem>
         <para>
-          The working directory is no more a temp directory created by nix-build, but the current directory. Therefore, hello-2.9 has been unpacked there.
+          The working directory is no more a temp directory created by nix-build, but the current directory. Therefore, hello-2.10 has been unpacked there.
         </para>
       </listitem>
     </itemizedlist>
 
     <para>
-      We're able to <command>cd</command> into hello-2.9 and type
+      We're able to <command>cd</command> into hello-2.10 and type
       <command>make</command>, because now it's available.
     </para>
 

--- a/pills/19/hello-derivation.txt
+++ b/pills/19/hello-derivation.txt
@@ -2,7 +2,7 @@ $ pp-aterm -i $(nix-instantiate hello.nix)
 Derive(
   [("out", "/nix/store/6flbdbpq6sc1dc79xjx01bz43zwgj3wc-hello", "", "")]
 , [("/nix/store/8z4xw8a0ax1csa0l83zflsm4jw9c94w2-bash-4.3-p39.drv", ["out"]), ("/nix/store/j0905apmxw2qb4ng5j40d4ghpiwa3mi1-stdenv.drv", ["out"])]
-, ["/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.9.tar.gz", "/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh"]
+, ["/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.10.tar.gz", "/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh"]
 , "x86_64-linux"
 , "/nix/store/zmd4jk4db5lgxb8l93mhkvr3x92g2sx2-bash-4.3-p39/bin/bash"
 , ["-e", "/nix/store/9krlzvny65gdc8s7kpb6lkx8cd02c25b-default-builder.sh"]
@@ -13,7 +13,7 @@ Derive(
   , ("out", "/nix/store/6flbdbpq6sc1dc79xjx01bz43zwgj3wc-hello")
   , ("propagatedBuildInputs", "")
   , ("propagatedNativeBuildInputs", "")
-  , ("src", "/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.9.tar.gz")
+  , ("src", "/nix/store/0q6pfasdma4as22kyaknk4kwx4h58480-hello-2.10.tar.gz")
   , ("stdenv", "/nix/store/k4jklkcag4zq4xkqhkpy156mgfm34ipn-stdenv")
   , ("system", "x86_64-linux")
   ]

--- a/pills/19/stdenv-hello.txt
+++ b/pills/19/stdenv-hello.txt
@@ -1,5 +1,5 @@
 with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "hello";
-  src = ./hello-2.9.tar.gz;
+  src = ./hello-2.10.tar.gz;
 }

--- a/pills/19/stdenv-setup-fake-builder.txt
+++ b/pills/19/stdenv-setup-fake-builder.txt
@@ -1,8 +1,8 @@
 $ nix-shell -E 'derivation { name = "fake"; builder = "fake"; system = "x86_64-linux"; }'
 nix-shell$ unset PATH
 nix-shell$ source /nix/store/k4jklkcag4zq4xkqhkpy156mgfm34ipn-stdenv/setup
-nix-shell$ tar -xf hello-2.9.tar.gz
-nix-shell$ cd hello-2.9
+nix-shell$ tar -xf hello-2.10.tar.gz
+nix-shell$ cd hello-2.10
 nix-shell$ configurePhase
 ...
 nix-shell$ buildPhase


### PR DESCRIPTION
I was just going through the pills and found the GNU Hello version was one behind. This PR updates pill 8 to use the latest GNU Hello.