### PR TITLE
Pill 8: Fix missing ar binary in build environment

### DIFF
--- a/pills/08/autotools-nix.txt
+++ b/pills/08/autotools-nix.txt
@@ -3,7 +3,7 @@ pkgs: attrs:
   let defaultAttrs = {
     builder = "${bash}/bin/bash";
     args = [ ./builder.sh ];
-    baseInputs = [ gnutar gzip gnumake gcc binutils coreutils gawk gnused gnugrep ];
+    baseInputs = [ gnutar gzip gnumake gcc binutils-unwrapped coreutils gawk gnused gnugrep ];
     buildInputs = [];
     system = builtins.currentSystem;
   };

--- a/pills/08/hello-builder.txt
+++ b/pills/08/hello-builder.txt
@@ -1,4 +1,4 @@
-export PATH="$gnutar/bin:$gcc/bin:$gnumake/bin:$coreutils/bin:$gawk/bin:$gzip/bin:$gnugrep/bin:$gnused/bin:$binutils/bin"
+export PATH="$gnutar/bin:$gcc/bin:$gnumake/bin:$coreutils/bin:$gawk/bin:$gzip/bin:$gnugrep/bin:$gnused/bin:$binutils_unwrapped/bin"
 tar -xzf $src
 cd hello-2.9
 ./configure --prefix=$out

--- a/pills/08/hello-nix-rev-1.txt
+++ b/pills/08/hello-nix-rev-1.txt
@@ -3,7 +3,7 @@ derivation {
   name = "hello";
   builder = "${bash}/bin/bash";
   args = [ ./builder.sh ];
-  buildInputs = [ gnutar gzip gnumake gcc binutils coreutils gawk gnused gnugrep ];
+  buildInputs = [ gnutar gzip gnumake gcc binutils-unwrapped coreutils gawk gnused gnugrep ];
   src = ./hello-2.9.tar.gz;
   system = builtins.currentSystem;
 }

--- a/pills/08/hello-nix.txt
+++ b/pills/08/hello-nix.txt
@@ -3,7 +3,7 @@ derivation {
   name = "hello";
   builder = "${bash}/bin/bash";
   args = [ ./hello_builder.sh ];
-  inherit gnutar gzip gnumake gcc binutils coreutils gawk gnused gnugrep;
+  inherit gnutar gzip gnumake gcc binutils-unwrapped coreutils gawk gnused gnugrep;
   src = ./hello-2.9.tar.gz;
   system = builtins.currentSystem;
 }


### PR DESCRIPTION
`binutils` is missing `ar` causing the compilation of GNU hello to fail, switching to `binutils-unwrapped` corrects the issue as this has `ar` in the environment.