### PR TITLE
Add missing space in recursive attributes example

### DIFF
--- a/pills/04/set-recursive.txt
+++ b/pills/04/set-recursive.txt
@@ -1,2 +1,2 @@
-nix-repl> rec { a= 3; b = a+4; }
+nix-repl> rec { a = 3; b = a+4; }
 { a = 3; b = 7; }


### PR DESCRIPTION
Minor update adding a space for consistency with the formatting of the other examples in this section.