### PR TITLE
Pill 07: Make the input file name explicit.

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -182,7 +182,7 @@
   <section>
     <title>Packaging a simple C program</title>
     <para>
-      Start off by writing a simple C program:
+      Start off by writing a simple C program called <filename>simple.c</filename>:
 
       <programlisting><xi:include href="./07/simple.c.txt" parse="text" /></programlisting>
 


### PR DESCRIPTION
Hi,
my first intuition was to name the file ``main.c`` and I was curious whether this was right. It could have been another sane "default" but its not. I believe this helps the novice.