### PR TITLE
Nix on darwin note: use a `<note>` element

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -48,12 +48,12 @@
     </para>
 
     <screen><xi:include href="./08/hello-nix.txt" parse="text" /></screen>
-    <sidebar><title>Nix on darwin</title>
+    <note><title>Nix on darwin</title>
     <para>The darwin (i.e. macOS) <literal>stdenv</literal> diverges from the Linux <literal>stdenv</literal> in several ways. A main difference is that the darwin <literal>stdenv</literal> relies upon <literal>clang</literal> rather than <literal>gcc</literal> as its C compiler. We can adapt this early example of how a <literal>stdenv</literal> works for darwin by using this modified version of <filename>hello.nix</filename>:
     </para>
     <screen><xi:include href="./08/hello-nix-darwin.txt" parse="text" /></screen>
     Please be aware that similar changes may be needed in what follows.
-    </sidebar>
+    </note>
 
     <para>
       Now build it with <command>nix-build hello.nix</command> and you can

--- a/style.css
+++ b/style.css
@@ -266,14 +266,3 @@ table.simplelist
 div.navheader table, div.navfooter table {
     box-shadow: none;
 }
-
-div.sidebar
-{
-    float: right;
-    margin: 1em 5%;
-    padding: 10px;
-    border: 2px dashed #b0b0b0;
-    border-radius: 0.4em;
-    background: #f8f8fc;
-    box-shadow: 0.4em 0.4em 0.5em #e0e0e0;
-}


### PR DESCRIPTION
This takes advantage of existing styling support.