### PR TITLE
pill 18.1: Fix filename typo

### DIFF
--- a/pills/18-nix-store-paths.xml
+++ b/pills/18-nix-store-paths.xml
@@ -27,7 +27,7 @@
     <para>
       Now inspect the .drv to see where is <filename>./myfile</filename> being stored:
     </para>
-    <xi:include href="./18/derivation-simple-contents.xml" />
+    <xi:include href="./18/derivation-simple-content.xml" />
     <para>
       Great, how did nix decide to use <literal>xv2iccirbrvklck36f1g7vldn5v58vck</literal> ? Keep looking at the nix comments.
     </para>


### PR DESCRIPTION
There seams to be a typo in the path of the included file: https://nixos.org/nixos/nix-pills/nix-store-paths.html#idm140737315515840

`derivation-simple-contents.xml -> derivation-simple-content.xml`