### PR TITLE
Update documentation after Nix 2.0 switch

### DIFF
--- a/pills/02-install-on-your-running.xml
+++ b/pills/02-install-on-your-running.xml
@@ -151,10 +151,10 @@
 
     <xi:include href="./02/profile.xml" parse="xml" />
     <para>
-     That <package>nix-1.7</package> derivation in the Nix store is
+     That <package>nix-2.1.3</package> derivation in the Nix store is
      Nix itself, with binaries and libraries. The process of "installing" 
      the derivation in the profile basically reproduces the hierarchy of the
-     <package>nix-1.7</package> store derivation in the profile by means of
+     <package>nix-2.1.3</package> store derivation in the profile by means of
      symbolic links.
     </para>
     <para>

--- a/pills/02/profile.xml
+++ b/pills/02/profile.xml
@@ -1,6 +1,6 @@
 <screen>$ ls -l ~/.nix-profile/
-bin -> /nix/store/clnpynyac3hx3a6z5lsy893p7b4rwnyf-<emphasis role="strong">nix-1.7</emphasis>/bin
+bin -> /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-<emphasis role="strong">nix-2.1.3</emphasis>/bin
 [...]
-manifest.nix -> /nix/store/82dg18wz250vvcxjbclgyy5yg2kfz1gw-<emphasis role="strong">env-manifest.nix</emphasis>
+manifest.nix -> /nix/store/q8b5238akq07lj9gfb3qb5ycq4dxxiwm-<emphasis role="strong">env-manifest.nix</emphasis>
 [...]
-share -> /nix/store/clnpynyac3hx3a6z5lsy893p7b4rwnyf-<emphasis role="strong">nix-1.7</emphasis>/share</screen>
+share -> /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-<emphasis role="strong">nix-2.1.3</emphasis>/share</screen>

--- a/pills/02/user-environment.xml
+++ b/pills/02/user-environment.xml
@@ -1,4 +1,4 @@
 <screen>creating /home/nix/.nix-profile
-installing `nix-1.7'
-ebuilding path(s) `/nix/store/xxhdgml3rshn8mkaqxb86gp4r276sp9d-<emphasis role="strong">user-environment</emphasis>'
-created 6 symlinks in user environment</screen>
+installing 'nix-2.1.3'
+building path(s) `/nix/store/a7p1w3z2h8pl00ywvw6icr3g5l9vm5r7-<emphasis role="strong">user-environment</emphasis>'
+created 7 symlinks in user environment</screen>

--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -31,7 +31,7 @@
     <screen><xi:include href="./03/source-nix.txt" parse="text" /></screen>
 
     <para>
-      To remind you, <literal>~/.nix-profile/etc</literal> points to the <literal>nix-1.7</literal>
+      To remind you, <literal>~/.nix-profile/etc</literal> points to the <literal>nix-2.1.3</literal>
       derivation. At this point, we are in our Nix user profile.
     </para>
   </section>
@@ -41,20 +41,19 @@
 
     <para>
       Finally something practical! Installation into the Nix environment is an
-      interesting process. Let's install <literal>nix-repl</literal>, a simple command line tool
-      for playing with the Nix language. Yes, Nix is a <link xlink:href="http://nixos.org/nix/manual/#idm47361539226272">
-        pure, lazy, functional language</link>, not only a set of tools to
-      manage derivations.
+      interesting process. Let's install <literal>hello</literal>, a simple CLI
+      tool which prints <literal>Hello world</literal> and is mainly used to test compilers
+      and package installations.
     </para>
 
     <para>
       Back to the installation:
     </para>
 
-    <screen><xi:include href="./03/install-repl.txt" parse="text" /></screen>
+    <screen><xi:include href="./03/install-hello.txt" parse="text" /></screen>
 
     <para>
-      Now you can run <literal>nix-repl</literal>. Things to notice:
+      Now you can run <literal>hello</literal>. Things to notice:
     </para>
     <itemizedlist>
       <listitem>
@@ -77,7 +76,7 @@
       </listitem>
       <listitem>
         <para>
-          We installed <literal>nix-repl</literal> by derivation name minus the version. I repeat:
+          We installed <literal>hello</literal> by derivation name minus the version. I repeat:
           we specified the <emphasis role="bold">derivation name</emphasis>
           (minus the version) to install it.
         </para>
@@ -97,9 +96,9 @@
     <screen><xi:include href="./03/list-installed-derivations.txt" parse="text" /></screen>
 
     <para>
-      So, where did <literal>nix-repl</literal> really get installed?
-      <literal>which nix-repl</literal> is
-      <literal>~/.nix-profile/bin/nix-repl</literal> which points to the store.
+      So, where did <literal>hello</literal> really get installed?
+      <literal>which hello</literal> is
+      <literal>~/.nix-profile/bin/hello</literal> which points to the store.
       We can also list the derivation paths with <command>nix-env -q --out-path</command>. So
       that's what those derivation paths are called: the
       <emphasis role="bold">output</emphasis> of a build.
@@ -127,9 +126,9 @@
     <screen><xi:include href="./03/ls-nix-profile.txt" parse="text" /></screen>
 
     <para>
-      Now that's interesting. When only <literal>nix-1.7</literal> was installed, <filename>bin</filename> was a
-      symlink to <literal>nix-1.7</literal>. Now that we've actually installed some things
-      (<literal>man</literal>, <literal>nix-repl</literal>), it's a real directory, not a symlink.
+      Now that's interesting. When only <literal>nix-2.1.3</literal> was installed, <filename>bin</filename> was a
+      symlink to <literal>nix-2.1.3</literal>. Now that we've actually installed some things
+      (<literal>man</literal>, <literal>hello</literal>), it's a real directory, not a symlink.
     </para>
 
     <screen><xi:include href="./03/ls-profile-bin.txt" parse="text" /></screen>
@@ -193,7 +192,7 @@
     </para>
 
     <para>
-      To show the direct runtime dependencies of <literal>nix-repl</literal>:
+      To show the direct runtime dependencies of <literal>hello</literal>:
     </para>
 
     <screen><xi:include href="./03/references.txt" parse="text" /></screen>
@@ -205,20 +204,20 @@
 
     <para>
       It may not make sense to you right now, but let's print reverse
-      dependencies of <literal>nix-repl</literal>:
+      dependencies of <literal>hello</literal>:
     </para>
 
     <screen><xi:include href="./03/referrers.txt" parse="text" /></screen>
 
     <para>
-      Was it what you expected? It turns out that our environments depend upon <literal>nix-repl</literal>.
-      Yes, that means that the environments are in the store, and since they contain symlinks to <literal>nix-repl</literal>,
-      therefore the environment depends upon <literal>nix-repl</literal>.
+      Was it what you expected? It turns out that our environments depend upon <literal>hello</literal>.
+      Yes, that means that the environments are in the store, and since they contain symlinks to <literal>hello</literal>,
+      therefore the environment depends upon <literal>hello</literal>.
     </para>
 
     <para>
       Two environments were listed, generation 2 and generation 3, since these are the ones that had
-      <literal>nix-repl</literal> installed in them.
+      <literal>hello</literal> installed in them.
     </para>
 
     <para>
@@ -295,9 +294,9 @@
     </para>
 
     <para>
-      First, pick one <literal>nix-1.7</literal> derivation:
-      <command>ls /nix/store/*nix-1.7</command>, say
-      <filename>/nix/store/g21di262aql6xskx15z3qiw3zh3wmjlb-nix-1.7</filename>.
+      First, pick one <literal>nix-2.1.3</literal> derivation:
+      <command>ls /nix/store/*nix-2.1.3</command>, say
+      <filename>/nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3</filename>.
     </para>
 
     <para>

--- a/pills/03/install-hello.txt
+++ b/pills/03/install-hello.txt
@@ -1,0 +1,4 @@
+$ nix-env -i hello
+installing 'hello-2.10'
+building '/nix/store/0vqw0ssmh6y5zj48yg34gc6macr883xk-user-environment.drv'...
+created 36 symlinks in user environment

--- a/pills/03/install-repl.txt
+++ b/pills/03/install-repl.txt
@@ -1,6 +1,0 @@
-$ nix-env -i nix-repl
-installing `nix-repl-1.7-1734e8a'
-these paths will be fetched (18.61 MiB download, 69.53 MiB unpacked):
-[...]
-building path(s) `/nix/store/f01lfzbw7n0yzhsjd33xfj77li9raljv-user-environment'
-created 24 symlinks in user environment

--- a/pills/03/install.txt
+++ b/pills/03/install.txt
@@ -1,1 +1,1 @@
-$ /nix/store/g21di262aql6xskx15z3qiw3zh3wmjlb-nix-1.7/bin/nix-env -i /nix/store/g21di262aql6xskx15z3qiw3zh3wmjlb-nix-1.7
+$ /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/bin/nix-env -i /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/bin/nix-env 

--- a/pills/03/list-installed-derivations.txt
+++ b/pills/03/list-installed-derivations.txt
@@ -1,3 +1,3 @@
 $ nix-env -q
-nix-1.7
-nix-repl-1.7-1734e8a
+nix-2.1.3
+hello-2.10

--- a/pills/03/ls-nix-profile.txt
+++ b/pills/03/ls-nix-profile.txt
@@ -1,4 +1,4 @@
 $ ls -l ~/.nix-profile/
 dr-xr-xr-x 2 nix nix 4096 Jan  1  1970 bin
-lrwxrwxrwx 1 nix nix   55 Jan  1  1970 etc -> /nix/store/clnpynyac3hx3a6z5lsy893p7b4rwnyf-nix-1.7/etc
+lrwxrwxrwx 1 nix nix   55 Jan  1  1970 etc -> /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/etc
 [...]

--- a/pills/03/ls-profile-bin.txt
+++ b/pills/03/ls-profile-bin.txt
@@ -2,7 +2,7 @@ $ ls -l ~/.nix-profile/bin/
 [...]
 man -> /nix/store/83cn9ing5sc6644h50dqzzfxcs07r2jn-man-1.6g/bin/man
 [...]
-nix-env -> /nix/store/clnpynyac3hx3a6z5lsy893p7b4rwnyf-nix-1.7/bin/nix-env
+nix-env -> /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/bin/nix-env
 [...]
-nix-repl -> /nix/store/0fcl92chxbbs8axb994rg12vxddg1ivs-nix-repl-1.7-1734e8a/bin/nix-repl
+hello -> /nix/store/58r35bqb4f3lxbnbabq718svq9i2pda3-hello-2.10/bin/hello
 [...]

--- a/pills/03/nix-env-rollback.txt
+++ b/pills/03/nix-env-rollback.txt
@@ -1,1 +1,1 @@
-$ /nix/store/g21di262aql6xskx15z3qiw3zh3wmjlb-nix-1.7/bin/nix-env --rollback
+$ /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/bin/nix-env --rollback

--- a/pills/03/references.txt
+++ b/pills/03/references.txt
@@ -1,6 +1,3 @@
-$ nix-store -q --references `which nix-repl`
-/nix/store/94n64qy99ja0vgbkf675nyk39g9b978n-glibc-2.19
-/nix/store/8jm0wksask7cpf85miyakihyfch1y21q-gcc-4.8.3
-/nix/store/25lg5iqy68k25hdv17yac72kcnwlh4lm-boehm-gc-7.2d
-/nix/store/g21di262aql6xskx15z3qiw3zh3wmjlb-nix-1.7
-/nix/store/jxs2k83npdin18ysnd104xm4sy29m8xp-readline-6.2
+$ nix-store -q --references `which hello`
+/nix/store/fg4yq8i8wd08xg3fy58l6q73cjy8hjr2-glibc-2.27
+/nix/store/58r35bqb4f3lxbnbabq718svq9i2pda3-hello-2.10

--- a/pills/03/referrers.txt
+++ b/pills/03/referrers.txt
@@ -1,5 +1,4 @@
-$ nix-store -q --referrers `which nix-repl`
-/nix/store/8rj57vahlndqwg4q095x5qvfa1g4rmvr-env-manifest.nix
-/nix/store/9c8ak2h7c6vbr9kqk8i2n96bwg55br7y-env-manifest.nix
-/nix/store/dr1y2saask2k4y2wrmxw443302pp02z2-user-environment
-/nix/store/f01lfzbw7n0yzhsjd33xfj77li9raljv-user-environment
+$ nix-store -q --referrers `which hello`
+/nix/store/58r35bqb4f3lxbnbabq718svq9i2pda3-hello-2.10
+/nix/store/fhvy2550cpmjgcjcx5rzz328i0kfv3z3-env-manifest.nix
+/nix/store/mp987abm20c70pl8p31ljw1r5by4xwfw-user-environment

--- a/pills/03/uninstall-all.txt
+++ b/pills/03/uninstall-all.txt
@@ -1,5 +1,4 @@
 $ nix-env -e '*'
-uninstalling `man-1.6g'
-uninstalling `nix-repl-1.7-1734e8a'
-uninstalling `nix-1.7'
+uninstalling 'hello-2.10'
+uninstalling 'nix-2.1.3'
 [...]

--- a/pills/04-basics-of-language.xml
+++ b/pills/04-basics-of-language.xml
@@ -49,15 +49,17 @@
     <title>Value types</title>
 
     <para>
-      We've installed <literal>nix-repl</literal> in the previous pill. If you didn't,
-      <command>nix-env -i nix-repl</command>. The <literal>nix-repl</literal> syntax is slightly
+      Nix 2.0 contains a command named <command>nix repl</command> which is a simple command line tool
+      for playing with the Nix language. In fact, Nix is a
+      <link xlink:href="http://nixos.org/nix/manual/#idm47361539226272">pure, lazy, functional language</link>,
+      not only a set of tools to manage derivations. The <literal>nix repl</literal> syntax is slightly
       different to Nix syntax when it comes to assigning variables, but it shouldn't
-      be confusing so long as you bear it in mind. I prefer to start with <literal>nix-repl</literal>
+      be confusing so long as you bear it in mind. I prefer to start with <literal>nix repl</literal>
       before cluttering your mind with more complex expressions.
     </para>
 
     <para>
-      Launch <literal>nix-repl</literal>. First of all, Nix supports basic arithmetic operations:
+      Launch <literal>nix repl</literal>. First of all, Nix supports basic arithmetic operations:
       <literal>+</literal>, <literal>-</literal>, and <literal>*</literal>. Integer division can be
       done with <literal>builtins.div</literal>.
     </para>
@@ -157,7 +159,7 @@
     <screen><xi:include href="./04/interpolate.txt" parse="text" /></screen>
 
     <para>
-      Note: ignore the <literal>foo = "strval"</literal> assignment, special syntax in <literal>nix-repl</literal>.
+      Note: ignore the <literal>foo = "strval"</literal> assignment, special syntax in <literal>nix repl</literal>.
     </para>
 
     <para>

--- a/pills/05-functions-and-imports.xml
+++ b/pills/05-functions-and-imports.xml
@@ -52,7 +52,7 @@ xml:id="functions-and-imports">
   <screen><xi:include href="./05/named-function.txt" parse="text" /></screen>
 
   <para>
-    As usual, please ignore the special syntax for assignments inside nix-repl.
+    As usual, please ignore the special syntax for assignments inside <literal>nix repl</literal>.
     So, we defined a function <code>x: x*2</code> that takes one parameter
     <code>x</code>, and returns
     <code>x*2</code>. This function is then assigned to the variable

--- a/pills/06-our-first-derivation.xml
+++ b/pills/06-our-first-derivation.xml
@@ -80,7 +80,7 @@
 
   <para>
     Oh oh, what's that? Did it build the derivation? No it didn't, but it
-    <emphasis role="strong">did create the .drv file</emphasis>. nix-repl does
+    <emphasis role="strong">did create the .drv file</emphasis>. <literal>nix repl</literal> does
     not build derivations unless you tell to do so.
   </para>
 
@@ -207,7 +207,7 @@
   <screen><xi:include href="./06/build-derivation.txt" parse="text" /></screen>
 
   <para>
-    The <code>:b</code> is a nix-repl specific command to build a derivation.
+    The <code>:b</code> is a <literal>nix repl</literal> specific command to build a derivation.
     You can see more commands with <code>:?</code> . So in the output you can
     see that it takes the <filename>.drv</filename> as information on how to
     build the derivation. Then it says it's trying to produce our out path.
@@ -216,8 +216,8 @@
   </para>
 
   <para>
-    We're doing the build inside nix-repl, but what if we don't want to use
-    nix-repl? You can <emphasis role="strong">realise</emphasis> a
+    We're doing the build inside <literal>nix repl</literal>, but what if we don't want to use
+    <literal>nix repl</literal>? You can <emphasis role="strong">realise</emphasis> a
     <filename>.drv</filename> with:
   </para>
 
@@ -411,7 +411,7 @@
   <para>
     Nix does not build derivations <emphasis role="strong">during
     evaluation</emphasis> of Nix expressions. In fact, that's why we have to do
-    ":b drv" in nix-repl, or use nix-store -r in the first place.
+    ":b drv" in <literal>nix repl</literal>, or use nix-store -r in the first place.
   </para>
 
   <para>

--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -248,9 +248,9 @@
     </para>
   </section>
   <section>
-    <title>Enough of nix-repl</title>
+    <title>Enough of <literal>nix repl</literal></title>
     <para>
-      Drop out of <application>nix-repl</application> and write a file
+      Drop out of <application>nix repl</application> and write a file
       <filename>simple.nix</filename>:
 
       <programlisting><xi:include href="./07/simple.txt" parse="text" /></programlisting>
@@ -294,7 +294,7 @@
       The value returned by the nixpkgs function is a set. More specifically,
       it's a set of derivations. Using the <code>with</code> expression we bring
       them into scope. This is the same as what <command>:l</command> does in
-      <application>nix-repl</application>, so we can easily access derivations
+      <application>nix repl</application>, so we can easily access derivations
       such as <varname>bash</varname>, <varname>gcc</varname>, and
       <varname>coreutils</varname>.
     </para>

--- a/pills/12-inputs-design-pattern.xml
+++ b/pills/12-inputs-design-pattern.xml
@@ -123,7 +123,7 @@
     </para>
     <screen><xi:include href="./12/repository.txt" parse="text" /></screen>
     <para>
-      Ready to use! Try it with <command>nix-repl</command>:
+      Ready to use! Try it with <command>nix repl</command>:
     </para>
     <screen><xi:include href="./12/repository-test-nix-repl.txt" parse="text" /></screen>
     <para>

--- a/pills/12/repository-test-nix-repl.txt
+++ b/pills/12/repository-test-nix-repl.txt
@@ -1,4 +1,4 @@
-$ nix-repl
+$ nix repl
 nix-repl> :l default.nix
 Added 2 variables.
 nix-repl> hello

--- a/pills/14-override-design-pattern.xml
+++ b/pills/14-override-design-pattern.xml
@@ -83,7 +83,7 @@
       This <literal>override</literal> attribute is a function taking a set of new arguments, and returns the result of the original function called with the original arguments unified with the new arguments. What a mess.
     </para>
     <para>
-      Let's try it with nix-repl:
+      Let's try it with <literal>nix repl</literal>:
     </para>
     <screen><xi:include href="./14/nix-repl-make-overridable-test.txt" parse="text" /></screen>
     <para>

--- a/pills/14/nix-repl-make-overridable-test.txt
+++ b/pills/14/nix-repl-make-overridable-test.txt
@@ -1,4 +1,4 @@
-$ nix-repl
+$ nix repl
 nix-repl> :l lib.nix
 Added 1 variables.
 nix-repl> f = { a, b }: { result = a+b; }

--- a/pills/16/config-foo-bar.txt
+++ b/pills/16/config-foo-bar.txt
@@ -1,4 +1,4 @@
-$ nix-repl
+$ nix repl
 nix-repl> pkgs = import <nixpkgs> {}
 nix-repl> pkgs.config
 { }

--- a/pills/18/derivation-simple.txt
+++ b/pills/18/derivation-simple.txt
@@ -1,3 +1,3 @@
-$ nix-repl
+$ nix repl
 nix-repl> derivation { system = "x86_64-linux"; builder = ./myfile; name = "foo"; }
 «derivation /nix/store/y4h73bmrc9ii5bxg6i7ck6hsf5gqv8ck-foo.drv»


### PR DESCRIPTION
In #89 it has been reported that the third step can't be done as
`nix-repl` doesn't evaluate anymore on 18.09 and unstable as in both
cases an evaluation error will be thrown.

First of all this may confuse new users who want to learn Nix, but don't
know the ecosystem sufficiently to understand why the install failed.

As recent NixOS versions (unstable and 18.09) use Nix 2.0 by default and
unstable doesn't evaluate with Nix 1.x anymore it should be a safe thing
to do now.

This patch covers two aspects:

* Using Nix 2.0: I replayed the installation steps with `nix-env` to
  ensure that the steps and explanations provided in the first three
  chapters are still valid.

* Replacing `nix-repl` references: most of the cases it was sufficient
  to replace `nix-repl` with the newly introduced command `nix repl`.
  In chapter three `nix-repl` was used to demonstrate the installation
  of a package with `nix-env`. I decided to use `nix-index` as demo
  package as I figured this tool to be extremely helpful to locate
  packages by output files.

  The explanation that Nix is not only a tool for package/derivation
  management, but a functional language as well was moved to chapter
  four where the basics of the language were actually covered.

This change is just a first step towards an updated series, in the
future we may want to use even more Nix 2.0 features (such as
`nix-build` vs. `nix build` with `nix log`).

Fixes #89
Possibly supersedes #71