### PR TITLE
Update Attribute sets example and remove obsolete note

### DIFF
--- a/pills/04-basics-of-language.xml
+++ b/pills/04-basics-of-language.xml
@@ -211,12 +211,6 @@
 
     <screen><xi:include href="./04/set-basics.txt" parse="text" /></screen>
 
-    <note><para>
-      Here the string representation printed in the repl is wrong, you can't write
-      <literal>{ 123 = "num"; }</literal>, because 123 is not an identifier. You also need a semicolon
-      (<literal>;</literal>) after every key-value assignment.
-    </para></note>
-
     <para>
       For those reading Nix expressions from nixpkgs: do not confuse attribute sets with
       argument sets used in functions.

--- a/pills/04/set-basics.txt
+++ b/pills/04/set-basics.txt
@@ -1,3 +1,3 @@
 nix-repl> s = { foo = "bar"; a-b = "baz"; "123" = "num"; }
 nix-repl> s
-{ 123 = "num"; a-b = "baz"; foo = "bar"; }
+{ "123" = "num"; a-b = "baz"; foo = "bar"; }


### PR DESCRIPTION
The attribute name is quoted correctly by the REPL in nix 2.1.3:

```
⟫ nix repl                    
Welcome to Nix version 2.1.3. Type :? for help.

nix-repl> s = { foo = "bar"; a-b = "baz"; "123" = "num"; }

nix-repl> s
{ "123" = "num"; a-b = "baz"; foo = "bar"; }

nix-repl>
```