### PR TITLE
Fixed issue #87

### DIFF
--- a/pills/08/generic-builder.txt
+++ b/pills/08/generic-builder.txt
@@ -1,6 +1,6 @@
 set -e
 unset PATH
-for p in $buildInputs; do
+for p in $buildInputs $baseInputs; do
   export PATH=$p/bin${PATH:+:}$PATH
 done
 


### PR DESCRIPTION
builder.sh needs $baseInputs on the path as well as $buildInputs.