### PR TITLE
Fix erroneous link in pill 2

### DIFF
--- a/pills/02-install-on-your-running.xml
+++ b/pills/02-install-on-your-running.xml
@@ -17,7 +17,7 @@
     changed in our system after the installation.
     <emphasis role="bold">If you're using NixOS, Nix is already installed;
     you can skip to the <link
-    linkend="install-on-your-running-system">next</link> pill.</emphasis>
+    linkend="enter-environment">next</link> pill.</emphasis>
   </para>
 
   <para>


### PR DESCRIPTION
Just a small typo-fix: "next pill" link previous linked back to pill 2. I tested this by running

```
nix-build release.nix && firefox result/share/doc/nix-pills/index.html
```

and verifying that the link ended up pointing to the right place.