### PR TITLE
08: Fix display of darwin-specific code

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -50,9 +50,9 @@
     <screen><xi:include href="./08/hello-nix.txt" parse="text" /></screen>
     <note><title>Nix on darwin</title>
     <para>The darwin (i.e. macOS) <literal>stdenv</literal> diverges from the Linux <literal>stdenv</literal> in several ways. A main difference is that the darwin <literal>stdenv</literal> relies upon <literal>clang</literal> rather than <literal>gcc</literal> as its C compiler. We can adapt this early example of how a <literal>stdenv</literal> works for darwin by using this modified version of <filename>hello.nix</filename>:
-    </para>
     <screen><xi:include href="./08/hello-nix-darwin.txt" parse="text" /></screen>
     Please be aware that similar changes may be needed in what follows.
+    </para>
     </note>
 
     <para>


### PR DESCRIPTION
Previously, the screen being outside the para would prevent it from
being displayed.