### PR TITLE
Change sentence wording in 04-basics-of-language

### DIFF
--- a/pills/04-basics-of-language.xml
+++ b/pills/04-basics-of-language.xml
@@ -224,7 +224,7 @@
     <screen><xi:include href="./04/set-access.txt" parse="text" /></screen>
 
     <para>
-      Yes, you can use strings for to address keys which aren't valid identifiers.
+      Yes, you can use strings to address keys which aren't valid identifiers.
     </para>
 
     <para>


### PR DESCRIPTION
I think the for is unnecessary and can be confusing (at least for me).