### PR TITLE
show new output for :b

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -60,31 +60,19 @@
     </para>
 
     <para>
-      First of all, let's write our <filename>builder.sh</filename> in the
+      The builder needs to create something in the path
+      <varname>$out</varname>, be it a file or a directory.
+      We'll start with simplest possible builder;
+      it produces a single file containing the word "foo".
+      Create <filename>builder.sh</filename> in the
       current directory:
 
       <programlisting><xi:include href="./07/builder.sh.txt" parse="text" /></programlisting>
 
-      The command <literal>declare -xp</literal>
-      lists exported variables.
-      (<literal>declare</literal> is a builtin bash function.)
       As we covered in the previous pill, Nix computes the output path of the
       derivation. The resulting <literal>.drv</literal> file contains a list of
       environment variables passed to the builder. One of these is
       <varname>$out</varname>.
-    </para>
-    <para>
-      What we have to do is create something in the path
-      <varname>$out</varname>, be it a file or a directory. In this case we are
-      creating a file.
-    </para>
-
-    <para>
-      In addition, we print out the environment variables during the build
-      process. We cannot use <application>env</application> for this, because
-      <application>env</application> is part of
-      <application>coreutils</application> and we don't have a dependency to it
-      yet. We only have <application>bash</application> for now.
     </para>
 
     <para>
@@ -98,9 +86,9 @@
 
       <xi:include href="./07/simple-derivation.xml" />
 
-      We did it! The contents of
-      <filename>/nix/store/w024zci0x1hh1wj6gjq0jagkc1sgrf5r-<emphasis>foo</emphasis></filename>
-      is really foo. We've built our first derivation.
+      <xi:include href="./07/cat-foo.xml" />
+
+      We did it! We've built our first derivation.
     </para>
     <para>
       Note that we used <code>./builder.sh</code> and not
@@ -114,6 +102,30 @@
 
   <section>
     <title>The builder environment</title>
+    <para>
+      What environment variables does the builder have access to?
+      We can modify  <filename>builder.sh</filename> to find out.
+
+      <programlisting><xi:include href="./07/builder2.sh.txt" parse="text" /></programlisting>
+
+      The command <literal>declare -xp</literal>
+      lists exported variables.
+      (<literal>declare</literal> is a builtin bash function.)
+      We cannot use <application>env</application> for this, because
+      <application>env</application> is part of
+      <application>coreutils</application> and we don't have a dependency to it
+      yet. We only have <application>bash</application> for now.
+    </para>
+      Create the derivation as you did before.
+
+      <xi:include href="./07/simple-derivation2.xml" />
+
+      Notice that a new path was assigned to <varname>$out</varname>.
+      Let's examine the file produced by this new version of the builder.
+
+      <xi:include href="./07/cat-declare.xml" />
+    <para>
+    </para>
     <para>
       Let's inspect those environment variables printed during the build process.
       <itemizedlist>

--- a/pills/07/builder.sh.txt
+++ b/pills/07/builder.sh.txt
@@ -1,2 +1,1 @@
-declare -xp
 echo foo > $out

--- a/pills/07/builder2.sh.txt
+++ b/pills/07/builder2.sh.txt
@@ -1,0 +1,1 @@
+declare -xp > $out

--- a/pills/07/cat-declare.xml
+++ b/pills/07/cat-declare.xml
@@ -1,0 +1,19 @@
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>cat /nix/store/0l6b6p86r73a9vlf7rfl9rdmgzh8jcwb-foo</userinput>
+<computeroutput>declare -x HOME="/homeless-shelter"
+declare -x NIX_BUILD_CORES="0"
+declare -x NIX_BUILD_TOP="/build"
+declare -x NIX_LOG_FD="2"
+declare -x NIX_STORE="/nix/store"
+declare -x OLDPWD
+declare -x PATH="/path-not-set"
+declare -x PWD="/build"
+declare -x SHLVL="1"
+declare -x TEMP="/build"
+declare -x TEMPDIR="/build"
+declare -x TERM="xterm-256color"
+declare -x TMP="/build"
+declare -x TMPDIR="/build"
+declare -x builder="/nix/store/czx8vkrb9jdgjyz8qfksh10vrnqa723l-bash-4.4-p23/bin/bash"
+declare -x name="foo"
+declare -x out="/nix/store/0l6b6p86r73a9vlf7rfl9rdmgzh8jcwb-foo"
+declare -x system="x86_64-linux"</computeroutput></screen>

--- a/pills/07/cat-foo.xml
+++ b/pills/07/cat-foo.xml
@@ -1,0 +1,2 @@
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>cat /nix/store/mypzica2nmd4w5c6faz49da97nih3k1y-foo</userinput>
+<computeroutput>foo</computeroutput></screen>

--- a/pills/07/simple-derivation.xml
+++ b/pills/07/simple-derivation.xml
@@ -1,27 +1,6 @@
 <screen xmlns="http://docbook.org/ns/docbook"><prompt>nix-repl> </prompt><userinput>d = derivation { name = "foo"; builder = "${bash}/bin/bash"; args = [ ./builder.sh ]; system = builtins.currentSystem; }</userinput>
 <prompt>nix-repl> </prompt><userinput>:b d</userinput>
-<computeroutput>these derivations will be built:
-  /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>
-building '/nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>'...
-declare -x HOME="/homeless-shelter"
-declare -x NIX_BUILD_CORES="4"
-declare -x NIX_BUILD_TOP="/tmp/nix-build-foo.drv-0"
-declare -x NIX_LOG_FD="2"
-declare -x NIX_STORE="/nix/store"
-declare -x OLDPWD
-declare -x PATH="/path-not-set"
-declare -x PWD="/tmp/nix-build-foo.drv-0"
-declare -x SHLVL="1"
-declare -x TEMP="/tmp/nix-build-foo.drv-0"
-declare -x TEMPDIR="/tmp/nix-build-foo.drv-0"
-declare -x TMP="/tmp/nix-build-foo.drv-0"
-declare -x TMPDIR="/tmp/nix-build-foo.drv-0"
-declare -x builder="/nix/store/q1g0rl8zfmz7r371fp5p42p4acmv297d-bash-4.4-p19/bin/bash"
-declare -x name="foo"
-declare -x out="/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-foo"
-declare -x system="x86_64-linux"
-warning: you did not specify '--add-root'; the result might be removed by the garbage collector
-/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis>
+<computeroutput>[1 built, 0.0 MiB DL]
 
 this derivation produced the following outputs:
-  out -> /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></computeroutput></screen>
+  out -> /nix/store/mypzica2nmd4w5c6faz49da97nih3k1y-<emphasis>foo</emphasis></computeroutput></screen>

--- a/pills/07/simple-derivation2.xml
+++ b/pills/07/simple-derivation2.xml
@@ -1,0 +1,8 @@
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>nix-repl> </prompt><userinput>:l &lt;nixpkgs></userinput>
+<computeroutput>Added 3950 variables.</computeroutput>
+<prompt>nix-repl> </prompt><userinput>d = derivation { name = "foo"; builder = "${bash}/bin/bash"; args = [ ./builder.sh ]; system = builtins.currentSystem; }</userinput>
+<prompt>nix-repl> </prompt><userinput>:b d</userinput>
+<computeroutput>[1 built, 0.0 MiB DL]
+
+this derivation produced the following outputs:
+  out -> /nix/store/0l6b6p86r73a9vlf7rfl9rdmgzh8jcwb-<emphasis>foo</emphasis></computeroutput></screen>


### PR DESCRIPTION
The output from the current version of `:b` in the nix repl shows less information, so when the first derivation is built, the environment isn't printed to the screen. As a result, the purpose of putting `declare -xp` into the builder script is no longer clear.

Therefore, I split the example into two parts 1) using a builder script that simply echoes "foo" to $out, and 2) a builder script that writes the environment to $out. I think this makes it easier for the user to follow the steps.