### PR TITLE
update pill 7.2 with `nix log`, add clarification

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -67,11 +67,21 @@
 
       The command <literal>declare -xp</literal>
       lists exported variables
-      (<literal>declare</literal> is a builtin bash function).
+      (<literal>declare</literal> is a builtin bash function). If you try out
+      <literal>declare -xp</literal> in the terminal now, you should see
+      a long list of variables like <literal>TERM="xterm"</literal>.
       As we covered in the previous pill, Nix computes the output path of the
       derivation. The resulting <literal>.drv</literal> file contains a list of
-      environment variables passed to the builder. One of these is
-      <varname>$out</varname>.
+      environment variables passed to the builder, which are then available
+      for use by the builder script. The environment variables in 
+      the <literal>.drv</literal>
+      file are taken from the attributes of the derivation, with a few
+      nix-specific variables added automatically. One of these is 
+      <varname>$out</varname>. Since nix builders run in an environment that 
+      excludes outside variables, while including attributes supplied by the
+      derivation, we would expect the output of <literal>declare -xp</literal>
+      to look quite different if run within a builder script actually being
+      executed by nix. Let's have a look.
     </para>
     <para>
       What we have to do is create something in the path
@@ -81,7 +91,8 @@
 
     <para>
       In addition, we print out the environment variables during the build
-      process. We cannot use <application>env</application> for this, because
+      process, which will show the environment variables available to the
+      builder. We cannot use <application>env</application> for this, because
       <application>env</application> is part of
       <application>coreutils</application> and we don't have a dependency to it
       yet. We only have <application>bash</application> for now.
@@ -94,7 +105,9 @@
       <xi:include href="./07/bash.xml" />
 
       So with the usual trick, we can refer to
-      <application>bin/bash</application> and create our derivation:
+      <application>bin/bash</application> and create our derivation, and then use
+      <code>nix log</code> to view the logs created by the execution of our
+      builder script:
 
       <xi:include href="./07/simple-derivation.xml" />
 
@@ -115,7 +128,8 @@
   <section>
     <title>The builder environment</title>
     <para>
-      Let's inspect those environment variables printed during the build process.
+    As expected, the variables that <literal>declare -xp</literal> shows were
+    available to our builder script were quite different.
       <itemizedlist>
         <listitem><para>
           <envar>$HOME</envar> is not your home directory, and

--- a/pills/07/simple-derivation.xml
+++ b/pills/07/simple-derivation.xml
@@ -1,8 +1,13 @@
 <screen xmlns="http://docbook.org/ns/docbook"><prompt>nix-repl> </prompt><userinput>d = derivation { name = "foo"; builder = "${bash}/bin/bash"; args = [ ./builder.sh ]; system = builtins.currentSystem; }</userinput>
 <prompt>nix-repl> </prompt><userinput>:b d</userinput>
-<computeroutput>these derivations will be built:
-  /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>
-building '/nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>'...
+<computeroutput>[1 build, 0.0MiB DL]
+
+this derivation produced the following outputs:
+  out -> /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></computeroutput>
+
+<prompt>nix-repl> </prompt><userinput>nix log /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></userinput>
+
+<computeroutput>
 declare -x HOME="/homeless-shelter"
 declare -x NIX_BUILD_CORES="4"
 declare -x NIX_BUILD_TOP="/tmp/nix-build-foo.drv-0"
@@ -19,9 +24,4 @@ declare -x TMPDIR="/tmp/nix-build-foo.drv-0"
 declare -x builder="/nix/store/q1g0rl8zfmz7r371fp5p42p4acmv297d-bash-4.4-p19/bin/bash"
 declare -x name="foo"
 declare -x out="/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-foo"
-declare -x system="x86_64-linux"
-warning: you did not specify '--add-root'; the result might be removed by the garbage collector
-/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis>
-
-this derivation produced the following outputs:
-  out -> /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></computeroutput></screen>
+declare -x system="x86_64-linux"</computeroutput></screen>


### PR DESCRIPTION
In pill 7.2, the terminal output of `nix-repl> :b d` no longer includes the build logs, which makes the exercise in 7.2 very difficult to understand. As tomberek on the discourse pointed out, the logs showing the output of `declare -xp` should be viewed with `nix log <storepath>`. I also added a little bit of explanation to hopefully make it more clear what's happening, and why we're using `declare -xp` to print variables.