### PR TITLE
Add link to current NixOS Wiki and fix awkword wording

### DIFF
--- a/pills/01-why-you-should-give-it-try.xml
+++ b/pills/01-why-you-should-give-it-try.xml
@@ -32,9 +32,10 @@
     <para>
       The <link xlink:href="https://nixos.org/nix/manual/">Nix</link>,
       <link xlink:href="https://nixos.org/nixpkgs/manual/">Nixpkgs</link>, and
-      <link xlink:href="https://nixos.org/nixos/manual/">NixOS</link> manuals;
-      and wiki are excellent resources for explaining how Nix/NixOS works, how
-      you can use it, and the number of cool things being done with it.
+      <link xlink:href="https://nixos.org/nixos/manual/">NixOS</link> manuals
+      along with <link xlink:href="https://nixos.wiki/">the wiki</link> are
+      excellent resources for explaining how Nix/NixOS works, how
+      you can use it, and how cool things are being done with it.
       However, at the beginning you may feel that some of the magic
       which happens behind the scenes is hard to grasp.
     </para>


### PR DESCRIPTION
Currently, "1.2. Rationale for this series" starts out with the following sentence, which seems a bit odd:

> The Nix, Nixpkgs, and NixOS manuals; and wiki are excellent resources for explaining how Nix/NixOS works, how you can use it, and the number of cool things being done with it. 

Turns out https://github.com/NixOS/nix-pills/commit/4d0c1d27a5021c170a9591eb2fd0406321838644 removes an item followed by a semicolon. This commit fixes the issue by removing the semicolon and also adds a link to the current NixOS Wiki.