### PR TITLE
Update example command to install `man`

### DIFF
--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -117,7 +117,7 @@
       At this point you probably want to run <literal>man</literal> to get some documentation.
       Even if you
       already have man system-wide outside of the Nix environment, you can
-      install and use it within Nix with <command>nix-env -i man</command>. As
+      install and use it within Nix with <command>nix-env -i man-db</command>. As
       usual, a new generation will be created, and <filename>~/.nix-profile</filename> will point to
       it.
     </para>


### PR DESCRIPTION
Following through the pill, I saw this example, however:
```
$ nix-env -i man
error: selector 'man' matches no derivations
```

So I searched for the package and found:
```
$ nix-env -q 'man.*'
man-db-2.9.3
```