### PR TITLE
Follow redirects when installing via `curl`

### DIFF
--- a/pills/02-install-on-your-running.xml
+++ b/pills/02-install-on-your-running.xml
@@ -30,7 +30,7 @@
     <title>Installation</title>
 
     <para>
-      To install Nix, run <command>curl https://nixos.org/nix/install | sh</command>
+      To install Nix, run <command>curl -L https://nixos.org/nix/install | sh</command>
       as a non-root user and follow the instructions. Alternatively, you may
       prefer to download the installation script and verify its integrity using
       GPG signatures. Instructions for doing so can be found here: <link


### PR DESCRIPTION
I came across this when trying to install on a fresh VPS instance. The `-L` flag was necessary to get it to work.

For reference, here is the (request elided) response part when running `curl https://nixos.org/nix/install --verbose`

```
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* Connection state changed (MAX_CONCURRENT_STREAMS == 150)!
< HTTP/2 301
< age: 21
< content-length: 0
< date: Thu, 10 Sep 2020 08:15:30 GMT
< location: https://releases.nixos.org/nix/nix-2.3.7/install
< server: Netlify
< via: 1.1 42f9f0e9bd0296c3bb45648019b2dce5.cloudfront.net (CloudFront)
< x-amz-cf-id: KnFHvob-NJ_lChDqqK4tnjrWyo2fo_FOoSkLrcsOYyrBXz4mLdsWkQ==
< x-amz-cf-pop: LAX3-C3
< x-cache: Hit from cloudfront
< x-nf-request-id: 6500914d-212f-4bc7-be1c-1678343eee6f-19883675
```
