### PR TITLE
Change install arg from `man` to `man-db`

### DIFF
--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -117,7 +117,7 @@
       At this point you probably want to run <literal>man</literal> to get some documentation.
       Even if you
       already have man system-wide outside of the Nix environment, you can
-      install and use it within Nix with <command>nix-env -i man</command>. As
+      install and use it within Nix with <command>nix-env -i man-db</command>. As
       usual, a new generation will be created, and <filename>~/.nix-profile</filename> will point to
       it.
     </para>


### PR DESCRIPTION
The install command `nix-env -i man` does not work as `man` is the
*attribute name* meanwhile the command expects the derivation name which
is `man-db`. If using the attribute name then the command should use the
`{--attr | -A}` option and pass the attribute path, e.g.:
`nix-env -iA nixpkgs.man`.