### PR TITLE
Update link for the `//` operator

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -214,7 +214,7 @@
 
     <para>
       The
-      <link xlink:href="https://nixos.org/nix/manual/#idm140737322063856">// operator</link>
+      <link xlink:href="https://nixos.org/manual/nix/stable/#sec-language-operators">// operator</link>
       is an operator between two sets. The result is the union of the two sets.
       In case of conflicts between attribute names, the value on the right set
       is preferred.


### PR DESCRIPTION
The previous link leads to the top of the guide whereas the updated link
leads to Section *15.3 Operators* where one can quickly find the row in
the table that presents the `//` operator.