### PR TITLE
Re-word "modified setup.sh" in pill 10

### DIFF
--- a/pills/10-developing-with-nix-shell.xml
+++ b/pills/10-developing-with-nix-shell.xml
@@ -152,7 +152,7 @@
     <programlisting><xi:include href="./10/builder-sh.txt" parse="text" /></programlisting>
 
     <para>
-      Here is the modified <filename>setup.sh</filename>.
+      Here is the newly added <filename>setup.sh</filename>.
     </para>
 
     <programlisting><xi:include href="./10/setup-sh.txt" parse="text" /></programlisting>


### PR DESCRIPTION
Since `setup.sh` is a new addition, it makes more sense to not use the
word "modified", as it did not exist before :).