### PR TITLE
Fix 8.3 pill

### DIFF
--- a/pills/08/autotools-nix.txt
+++ b/pills/08/autotools-nix.txt
@@ -3,8 +3,7 @@ pkgs: attrs:
   let defaultAttrs = {
     builder = "${bash}/bin/bash";
     args = [ ./builder.sh ];
-    baseInputs = [ gnutar gzip gnumake gcc binutils-unwrapped coreutils gawk gnused gnugrep ];
-    buildInputs = [];
+    buildInputs = [ gnutar gzip gnumake gcc binutils-unwrapped coreutils gawk gnused gnugrep ];
     system = builtins.currentSystem;
   };
   in


### PR DESCRIPTION
Otherwise `/nix/store/86k2z0mc023y9qxn8gln4a6kj2a759gx-builder.sh: line 7: tar: No such file or directory`.