### PR TITLE
`b` is already defined in section 4.7 if the user follows along in the repl

### DIFF
--- a/pills/04/let-scope.txt
+++ b/pills/04/let-scope.txt
@@ -1,2 +1,2 @@
-nix-repl> let a = (let b = 3; in b); in b
-error: undefined variable `b' at (string):1:31
+nix-repl> let a = (let c = 3; in c); in c
+error: undefined variable `c' at (string):1:31


### PR DESCRIPTION
If a user follows along in the repl, the error won't occur as in section 4.6 the number 4 is assigned to `b`. To make this slightly less confusing and have the error appear as the user is following along we have to use a new variable.