### PR TITLE
Output of declare -xp is no longer visible in the repl

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -115,6 +115,11 @@
   <section>
     <title>The builder environment</title>
     <para>
+      We can use <command>nix-store --read-log</command> to see the logs our
+      builder produced:
+      <xi:include href="./07/read-log.xml" />
+    </para>
+    <para>
       Let's inspect those environment variables printed during the build process.
       <itemizedlist>
         <listitem><para>

--- a/pills/07/read-log.xml
+++ b/pills/07/read-log.xml
@@ -1,0 +1,18 @@
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix-store --read-log /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></userinput>
+<computeroutput>declare -x HOME="/homeless-shelter"
+declare -x NIX_BUILD_CORES="4"
+declare -x NIX_BUILD_TOP="/tmp/nix-build-foo.drv-0"
+declare -x NIX_LOG_FD="2"
+declare -x NIX_STORE="/nix/store"
+declare -x OLDPWD
+declare -x PATH="/path-not-set"
+declare -x PWD="/tmp/nix-build-foo.drv-0"
+declare -x SHLVL="1"
+declare -x TEMP="/tmp/nix-build-foo.drv-0"
+declare -x TEMPDIR="/tmp/nix-build-foo.drv-0"
+declare -x TMP="/tmp/nix-build-foo.drv-0"
+declare -x TMPDIR="/tmp/nix-build-foo.drv-0"
+declare -x builder="/nix/store/q1g0rl8zfmz7r371fp5p42p4acmv297d-bash-4.4-p19/bin/bash"
+declare -x name="foo"
+declare -x out="/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-foo"
+declare -x system="x86_64-linux"</computeroutput></screen>

--- a/pills/07/simple-derivation.xml
+++ b/pills/07/simple-derivation.xml
@@ -1,27 +1,6 @@
 <screen xmlns="http://docbook.org/ns/docbook"><prompt>nix-repl> </prompt><userinput>d = derivation { name = "foo"; builder = "${bash}/bin/bash"; args = [ ./builder.sh ]; system = builtins.currentSystem; }</userinput>
 <prompt>nix-repl> </prompt><userinput>:b d</userinput>
-<computeroutput>these derivations will be built:
-  /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>
-building '/nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis>'...
-declare -x HOME="/homeless-shelter"
-declare -x NIX_BUILD_CORES="4"
-declare -x NIX_BUILD_TOP="/tmp/nix-build-foo.drv-0"
-declare -x NIX_LOG_FD="2"
-declare -x NIX_STORE="/nix/store"
-declare -x OLDPWD
-declare -x PATH="/path-not-set"
-declare -x PWD="/tmp/nix-build-foo.drv-0"
-declare -x SHLVL="1"
-declare -x TEMP="/tmp/nix-build-foo.drv-0"
-declare -x TEMPDIR="/tmp/nix-build-foo.drv-0"
-declare -x TMP="/tmp/nix-build-foo.drv-0"
-declare -x TMPDIR="/tmp/nix-build-foo.drv-0"
-declare -x builder="/nix/store/q1g0rl8zfmz7r371fp5p42p4acmv297d-bash-4.4-p19/bin/bash"
-declare -x name="foo"
-declare -x out="/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-foo"
-declare -x system="x86_64-linux"
-warning: you did not specify '--add-root'; the result might be removed by the garbage collector
-/nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis>
+<computeroutput>[1 built, 0.0 MiB DL]
 
 this derivation produced the following outputs:
   out -> /nix/store/gczb4qrag22harvv693wwnflqy7lx5pb-<emphasis>foo</emphasis></computeroutput></screen>


### PR DESCRIPTION
Instead nix-store --read-log can be used to see the environment variables.

This commit fixes #106.