### PR TITLE
Make command output coherent with its text description.

### DIFF
--- a/pills/03/referrers.txt
+++ b/pills/03/referrers.txt
@@ -1,4 +1,6 @@
 $ nix-store -q --referrers `which hello`
 /nix/store/58r35bqb4f3lxbnbabq718svq9i2pda3-hello-2.10
 /nix/store/fhvy2550cpmjgcjcx5rzz328i0kfv3z3-env-manifest.nix
+/nix/store/yzdk0xvr0b8dcwhi2nns6d75k2ha5208-env-manifest.nix
 /nix/store/mp987abm20c70pl8p31ljw1r5by4xwfw-user-environment
+/nix/store/ppr3qbq7fk2m2pa49i2z3i32cvfhsv7p-user-environment


### PR DESCRIPTION
Command 'nix-store -q --referrers `which hello`' should list two
environments as described in the text: "Two environments were listed..."
Add a second environment and a manifest to the command output (hashes
were taken from the command output when trying to replay pill 3 steps on
a local system).