### PR TITLE
.travis.yml: drop non-working travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: nix
-sudo: false
-
-script: nix-build ./release.nix


### PR DESCRIPTION
All new pull requests get stuck in Travis CI checks since
last year. Let's drop Travis CI integration.