### PR TITLE
Update links to new nix manual structure

### DIFF
--- a/pills/01-why-you-should-give-it-try.xml
+++ b/pills/01-why-you-should-give-it-try.xml
@@ -30,9 +30,9 @@
   <section>
     <title>Rationale for this series</title>
     <para>
-      The <link xlink:href="https://nixos.org/nix/manual/">Nix</link>,
-      <link xlink:href="https://nixos.org/nixpkgs/manual/">Nixpkgs</link>, and
-      <link xlink:href="https://nixos.org/nixos/manual/">NixOS</link> manuals
+      The <link xlink:href="https://nixos.org/manual/nix">Nix</link>,
+      <link xlink:href="https://nixos.org/manual/nixpkgs/">Nixpkgs</link>, and
+      <link xlink:href="https://nixos.org/manual/nixos/">NixOS</link> manuals
       along with <link xlink:href="https://nixos.wiki/">the wiki</link> are
       excellent resources for explaining how Nix/NixOS works, how
       you can use it, and how cool things are being done with it.

--- a/pills/02-install-on-your-running.xml
+++ b/pills/02-install-on-your-running.xml
@@ -21,7 +21,7 @@
   </para>
 
   <para>
-     <link xlink:href="https://nixos.org/nix/manual/#chap-installation">Installing
+     <link xlink:href="https://nixos.org/manual/nix/stable/installation/installation.html">Installing
      Nix</link> is as easy as installing any other package.
      It will not drastically change our system, it will stay out of our way.
   </para>
@@ -54,7 +54,7 @@
       the store is owned by root and multiple users can install and build
       software through a Nix daemon. You can read more about multi-user
       installations here: <link
-      xlink:href="https://nixos.org/nix/manual/#ssec-multi-user">https://nixos.org/nix/manual/#ssec-multi-user</link>.
+      xlink:href="https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation">https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation</link>.
     </para></note>
   </section>
 
@@ -129,7 +129,7 @@
 
     <para>
       Next in the installation, we encounter the concept of the <link
-      xlink:href="https://nixos.org/nix/manual/#sec-profiles">profile</link>:
+      xlink:href="https://nixos.org/manual/nix/stable/package-management/profiles.html">profile</link>:
     </para>
 
     <xi:include href="./02/user-environment.xml" parse="xml" />
@@ -201,7 +201,7 @@
 
     <para>
       <link
-          xlink:href="https://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix
+          xlink:href="https://nixos.org/manual/nix/stable/expressions/writing-nix-expressions.html">Nix
       expressions</link> are used to describe packages and how to
       build them. <link
       xlink:href="https://nixos.org/nixpkgs/">Nixpkgs</link> is the

--- a/pills/03-enter-environment.xml
+++ b/pills/03-enter-environment.xml
@@ -75,7 +75,7 @@
       <listitem>
         <para>
           The <link
-          xlink:href="http://nixos.org/nix/manual/#sec-nix-env">nix-env</link>
+          xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-env.html">nix-env</link>
           tool manages environments, profiles and their generations.
         </para>
       </listitem>
@@ -124,7 +124,7 @@
 
     <para>
       Lets inspect the <link
-      xlink:href="http://nixos.org/nix/manual/#sec-profiles">profile</link>
+      xlink:href="https://nixos.org/manual/nix/stable/package-management/profiles.html">profile</link>
       a bit:
     </para>
 
@@ -176,9 +176,9 @@
 
     <para>
       You can of course also <link
-        xlink:href="https://nixos.org/nix/manual/#operation-uninstall">
+        xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---uninstall">
       uninstall</link> and <link
-      xlink:href="https://nixos.org/nix/manual/#operation-upgrade">upgrade</link> packages.
+      xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---upgrade">upgrade</link> packages.
     </para>
   </section>
 
@@ -325,7 +325,7 @@
       <link linkend="install-on-your-running-system">second article</link>.
       There's a list of channels from which we get packages, although usually we use a
       single channel. The tool to manage channels is
-      <link xlink:href="http://nixos.org/nix/manual/#sec-nix-channel">nix-channel</link>.
+      <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-channel.html">nix-channel</link>.
     </para>
 
     <screen><xi:include href="./03/channel-list.txt" parse="text" /></screen>
@@ -366,7 +366,7 @@
       We learned how to query the user environment and to manipulate it by
       installing and uninstalling software. Upgrading software is also straightforward,
       as you can read in
-      <link xlink:href="https://nixos.org/nix/manual/#operation-upgrade">the manual</link>
+      <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---upgrade">the manual</link>
       (<command>nix-env -u</command> will upgrade all packages in the
       environment).
     </para>

--- a/pills/04-basics-of-language.xml
+++ b/pills/04-basics-of-language.xml
@@ -16,9 +16,9 @@
 
   <para>
     The
-    <link xlink:href="http://nixos.org/nix/manual/#chap-writing-nix-expressions">Nix language</link>
+    <link xlink:href="https://nixos.org/manual/nix/stable/expressions/expression-language.html">Nix language</link>
     is used to write expressions that produce derivations. The
-    <link xlink:href="http://nixos.org/nix/manual/#sec-nix-build">nix-build</link>
+    <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-build.html">nix-build</link>
     tool is used to build derivations from an expression. Even as a system administrator that
     wants to customize the installation, it's necessary to master Nix. Using
     Nix for your jobs means you get the features we saw in the previous articles
@@ -51,7 +51,7 @@
     <para>
       Nix 2.0 contains a command named <command>nix repl</command> which is a simple command line tool
       for playing with the Nix language. In fact, Nix is a
-      <link xlink:href="https://nixos.org/nix/manual/#ch-expression-language">pure, lazy, functional language</link>,
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/expression-language.html">pure, lazy, functional language</link>,
       not only a set of tools to manage derivations. The <literal>nix repl</literal> syntax is slightly
       different to Nix syntax when it comes to assigning variables, but it shouldn't
       be confusing so long as you bear it in mind. I prefer to start with <literal>nix repl</literal>
@@ -96,7 +96,7 @@
 
     <para>
       Nix has integer, floating point, string, path, boolean and null
-      <link xlink:href="http://nixos.org/nix/manual/#ssec-values">simple</link>
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-values.html">simple</link>
       types. Then there are also lists, sets and functions. These types are enough
       to build an operating system.
     </para>
@@ -154,7 +154,7 @@
 
     <para>
       It's possible to
-      <link xlink:href="http://nixos.org/nix/manual/#ssec-values">interpolate</link>
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-values.html">interpolate</link>
       whole Nix expressions inside strings with the <literal>${...}</literal> syntax and only that syntax,
       not <literal>$foo</literal> or <literal>{$foo}</literal> or anything else.
     </para>
@@ -235,7 +235,7 @@
 
     <para>
       To do so, use
-      <link xlink:href="https://nixos.org/nix/manual/#idm140737322044432">recursive attribute sets</link>:
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html#recursive-sets">recursive attribute sets</link>:
     </para>
 
     <screen><xi:include href="./04/set-recursive.txt" parse="text" /></screen>

--- a/pills/05-functions-and-imports.xml
+++ b/pills/05-functions-and-imports.xml
@@ -19,7 +19,7 @@ xml:id="functions-and-imports">
     Functions help to build reusable components in a big repository like
     <link xlink:href="https://github.com/NixOS/nixpkgs/">nixpkgs</link>. The Nix
     manual has a <link
-    xlink:href="https://nixos.org/nix/manual/#ss-functions">great explanation of
+    xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html#functions">great explanation of
     functions</link>. Let's go: pill on one hand, Nix manual on the other hand.
   </para>
 
@@ -309,7 +309,7 @@ xml:id="functions-and-imports">
     <listitem>
       <para>
         <code>builtins.trace</code> is a <link
-        xlink:href="https://nixos.org/nix/manual/#ssec-builtins">built-in
+        xlink:href="https://nixos.org/manual/nix/stable/expressions/builtins.html">built-in
         function</link> that takes two arguments. The first is the message to
         display, the second is the value to return. It's usually used for
         debugging purposes.

--- a/pills/06-our-first-derivation.xml
+++ b/pills/06-our-first-derivation.xml
@@ -30,7 +30,7 @@
 
   <para>
     The <link
-    xlink:href="https://nixos.org/nix/manual/#ssec-derivation">derivation
+    xlink:href="https://nixos.org/manual/nix/stable/expressions/derivations.html">derivation
     built-in function</link> is used to create derivations. I invite you to read
     the link in the Nix manual about the derivation built-in. A derivation from
     a Nix language view point is simply a set, with some attributes. Therefore
@@ -426,7 +426,7 @@
         During evaluation, you can refer to other derivations because Nix will
         create .drv files and we will know out paths beforehand. This is
         achieved with <link
-        xlink:href="https://nixos.org/nix/manual/#sec-nix-instantiate">nix-instantiate</link>.
+        xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html">nix-instantiate</link>.
       </para>
     </listitem>
     <listitem>
@@ -434,7 +434,7 @@
         <emphasis role="strong">Realise/Build time</emphasis>: the .drv from the
         derivation set is built, first building .drv inputs (build
         dependencies). This is achieved with <link
-        xlink:href="https://nixos.org/nix/manual/#rsec-nix-store-realise">nix-store
+        xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-store.html#operation---realise">nix-store
         -r</link>.
       </para>
     </listitem>

--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -303,7 +303,7 @@
     </para>
     <para>
       Then we meet the
-      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html?highlight=inherit#inheriting-attributes"><code>inherit</code> keyword</link>.
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html#inheriting-attributes"><code>inherit</code> keyword</link>.
       <code>inherit foo;</code> is equivalent to <code>foo = foo;</code>.
       Similarly, <code>inherit foo bar;</code> is equivalent to <code>foo = foo; bar = bar;</code>.
     </para>

--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -128,7 +128,7 @@
         </para></listitem>
         <listitem><para>
           <envar>$NIX_BUILD_CORES</envar> and <envar>$NIX_STORE</envar> are
-          <link xlink:href="http://nixos.org/nix/manual/#sec-conf-file">nix
+          <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/conf-file.html">nix
           configuration options</link>
         </para></listitem>
         <listitem><para>
@@ -266,13 +266,13 @@
       <application>nix-build</application> does two jobs:
       <itemizedlist>
         <listitem><para>
-          <link xlink:href="http://nixos.org/nix/manual/#sec-nix-instantiate">
+          <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html">
             <application>nix-instantiate</application>
           </link>: parse and evaluate <filename>simple.nix</filename> and return
           the .drv file corresponding to the parsed derivation set
         </para></listitem>
         <listitem><para>
-            <link xlink:href="http://nixos.org/nix/manual/#rsec-nix-store-realise">
+            <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-store.html#operation---realise">
               <command>nix-store -r</command>
             </link>: realise the .drv file, which actually builds it.
         </para></listitem>
@@ -303,7 +303,7 @@
     </para>
     <para>
       Then we meet the
-      <link xlink:href="https://nixos.org/nix/manual/#idm140737322036688"><code>inherit</code> keyword</link>.
+      <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html?highlight=inherit#inheriting-attributes"><code>inherit</code> keyword</link>.
       <code>inherit foo;</code> is equivalent to <code>foo = foo;</code>.
       Similarly, <code>inherit foo bar;</code> is equivalent to <code>foo = foo; bar = bar;</code>.
     </para>

--- a/pills/09-automatic-runtime.xml
+++ b/pills/09-automatic-runtime.xml
@@ -260,9 +260,9 @@
       This makes packages self-contained, ensuring (apart data and
       configuration) that copying the runtime closure on another machine is
       sufficient to run the program. That's why Nix has
-      <link xlink:href="https://nixos.org/nix/manual/#ch-relnotes-0.8">one-click install</link>,
+      <link xlink:href="https://nixos.org/manual/nix/stable/release-notes/rl-0.8.html">one-click install</link>,
       or
-      <link xlink:href="http://nixos.org/nixops/manual/#chap-introduction">reliable deployment in the cloud</link>.
+      <link xlink:href="https://nixos.org/manual/nix/stable/introduction.html">reliable deployment in the cloud</link>.
       All with one tool.
     </para>
   </section>

--- a/pills/10-developing-with-nix-shell.xml
+++ b/pills/10-developing-with-nix-shell.xml
@@ -25,7 +25,7 @@
 
     <para>
       The <link
-      xlink:href="https://nixos.org/nix/manual/#sec-nix-shell">nix-shell</link>
+      xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-shell.html">nix-shell</link>
       tool drops us in a shell by setting up the necessary environment
       variables to hack on a derivation. It does not build the derivation, it
       only serves as a preparation so that we can run the build steps manually.

--- a/pills/11-garbage-collector.xml
+++ b/pills/11-garbage-collector.xml
@@ -61,7 +61,7 @@
 
     <para>
       In Nix there's this same concept. Instead of being objects, of course,
-      <link xlink:href="http://nixos.org/nix/manual/#ssec-gc-roots">GC roots are store paths</link>.
+      <link xlink:href="https://nixos.org/manual/nix/stable/package-management/garbage-collector-roots.html">GC roots are store paths</link>.
       The implementation is very simple and transparent to the user. GC roots
       are stored under <filename>/nix/var/nix/gcroots</filename>. If there's a
       symlink to a store path, then that store path is a GC root.
@@ -90,7 +90,7 @@
 
     <para>
       Before playing with the GC, first run the
-      <link xlink:href="http://nixos.org/nix/manual/#sec-nix-collect-garbage">nix garbage collector</link>
+      <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage.html">nix garbage collector</link>
       once, so that we have a clean playground for our experiments:
     </para>
 

--- a/pills/12-inputs-design-pattern.xml
+++ b/pills/12-inputs-design-pattern.xml
@@ -134,7 +134,7 @@
       The <arg>-A</arg> argument is used to access an attribute of the set from the given .nix expression.
     </para>
     <para>
-      <emphasis role="bold">Important:</emphasis> why did we choose the <filename>default.nix</filename>? Because when a directory (by default the current directory) has a <filename>default.nix</filename>, that <filename>default.nix</filename> will be used (see <literal>import</literal> <link xlink:href="http://nixos.org/nix/manual/#ssec-builtins">here</link>). In fact you can run <command>nix-build -A hello</command> without specifying <filename>default.nix</filename>.
+      <emphasis role="bold">Important:</emphasis> why did we choose the <filename>default.nix</filename>? Because when a directory (by default the current directory) has a <filename>default.nix</filename>, that <filename>default.nix</filename> will be used (see <literal>import</literal> <link xlink:href="https://nixos.org/manual/nix/stable/expressions/builtins.html">here</link>). In fact you can run <command>nix-build -A hello</command> without specifying <filename>default.nix</filename>.
     </para>
     <para>
       For pythoners, it is similar to <filename>__init__.py</filename>.

--- a/pills/13-callpackage-design-pattern.xml
+++ b/pills/13-callpackage-design-pattern.xml
@@ -124,7 +124,7 @@
       The "<literal>callPackage</literal>" pattern has simplified our repository a lot. We're able to import packages that require some named arguments and call them automatically, given the set of all packages.
     </para>
     <para>
-      We've also introduced some useful builtin functions that allows us to introspect Nix functions and manipulate attributes. These builtin functions are not usually used when packaging software, rather to provide tools for packaging. That's why they are not documented in the <link xlink:href="http://nixos.org/nix/manual/">nix manual</link>.
+      We've also introduced some useful builtin functions that allows us to introspect Nix functions and manipulate attributes. These builtin functions are not usually used when packaging software, rather to provide tools for packaging. That's why they are not documented in the <link xlink:href="https://nixos.org/manual/nix">nix manual</link>.
     </para>
     <para>
       Writing a repository in nix is an evolution of writing convenient functions for combining the packages. This demonstrates even more how nix is a generic tool to build and deploy something, and how suitable it is to create software repositories with your own conventions.

--- a/pills/15-nix-search-paths.xml
+++ b/pills/15-nix-search-paths.xml
@@ -14,7 +14,7 @@
   <section>
     <title>The NIX_PATH</title>
     <para>
-      The <link xlink:href="http://nixos.org/nix/manual/#sec-common-env">NIX_PATH environment variable</link> is very important. It's very similar to the <varname>PATH</varname> environment variable. The syntax is similar, several paths are separated by a colon <literal>:</literal>. Nix will then search for something in those paths from left to right.
+      The <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/env-common.html">NIX_PATH environment variable</link> is very important. It's very similar to the <varname>PATH</varname> environment variable. The syntax is similar, several paths are separated by a colon <literal>:</literal>. Nix will then search for something in those paths from left to right.
     </para>
     <para>
       Who uses <varname>NIX_PATH</varname>? The nix expressions! Yes, <varname>NIX_PATH</varname> is not of much use by the nix tools themselves, rather it's used when writing nix expressions.
@@ -29,7 +29,7 @@
       What's <varname>NIX_PATH</varname> good for? Nix expressions may refer to an "abstract" path such as <literal>&lt;nixpkgs&gt;</literal>, and it's possible to override it from the command line.
     </para>
     <para>
-      For ease we will use <command>nix-instantiate --eval</command> to do our tests. I remind you, <link xlink:href="http://nixos.org/nix/manual/#sec-nix-instantiate">nix-instantiate</link> is used to evaluate nix expressions and generate the .drv files. Here we are not interested in building derivations, so evaluation is enough. It can be used for one-shot expressions.
+      For ease we will use <command>nix-instantiate --eval</command> to do our tests. I remind you, <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html">nix-instantiate</link> is used to evaluate nix expressions and generate the .drv files. Here we are not interested in building derivations, so evaluation is enough. It can be used for one-shot expressions.
     </para>
   </section>
   <section>
@@ -62,7 +62,7 @@
       You can list that directory and realize it's simply a checkout of the nixpkgs repository at a specific commit (hint: <literal>.version-suffix</literal>).
     </para>
     <para>
-      The <varname>NIX_PATH</varname> variable is exported by <filename>nix.sh</filename>, and that's the reason why I always asked you to <link xlink:href="https://nixos.org/nix/manual/#ch-env-variables">source nix.sh</link> at the beginning of my posts.
+      The <varname>NIX_PATH</varname> variable is exported by <filename>nix.sh</filename>, and that's the reason why I always asked you to <link xlink:href="https://nixos.org/manual/nix/stable/installation/env-variables.html">source nix.sh</link> at the beginning of my posts.
     </para>
     <para>
       You may wonder: then I can also specify a different <link xlink:href="https://github.com/NixOS/nixpkgs">nixpkgs</link> path to, e.g., a <command>git checkout</command> of <literal>nixpkgs</literal>? Yes, you can and I encourage doing that. We'll talk about this in the next pill.
@@ -78,7 +78,7 @@
   <section>
     <title>A big word about nix-env</title>
     <para>
-      The <link xlink:href="http://nixos.org/nix/manual/#sec-nix-env">nix-env</link> command is a little different than <command>nix-instantiate</command> and <command>nix-build</command>. Whereas <command>nix-instantiate</command> and <command>nix-build</command> require a starting nix expression, <command>nix-env</command> does not.
+      The <link xlink:href="https://nixos.org/manual/nix/stable/command-ref/nix-env.html">nix-env</link> command is a little different than <command>nix-instantiate</command> and <command>nix-build</command>. Whereas <command>nix-instantiate</command> and <command>nix-build</command> require a starting nix expression, <command>nix-env</command> does not.
     </para>
     <para>
       You may be crippled by this concept at the beginning, you may think <command>nix-env</command> uses <varname>NIX_PATH</varname> to find the <literal>nixpkgs</literal> repository. But that's not it.

--- a/pills/18-nix-store-paths.xml
+++ b/pills/18-nix-store-paths.xml
@@ -96,7 +96,7 @@
       Finally, the other most used kind of path is when we know beforehand an integrity hash of a file. This is usual for tarballs.
     </para>
     <para>
-      A derivation can take three special attributes: <literal>outputHashMode</literal>, <literal>outputHash</literal> and <literal>outputHashAlgo</literal> which are well documented in the <link xlink:href="https://nixos.org/nix/manual/#sec-advanced-attributes">nix manual</link>.
+      A derivation can take three special attributes: <literal>outputHashMode</literal>, <literal>outputHash</literal> and <literal>outputHashAlgo</literal> which are well documented in the <link xlink:href="https://nixos.org/manual/nix/stable/expressions/advanced-attributes.html">nix manual</link>.
     </para>
     <para>
       The builder must create the out path and make sure its hash is the same as the one declared with <literal>outputHash</literal>.


### PR DESCRIPTION
I was following the nix pills, but since https://github.com/NixOS/nix/pull/3857, all links to the nix manual are broken (as mentioned in #152).

I replaced every link with the equivalent in the new manual structure.

Supersedes #152, #176.