### PR TITLE
Fix pill 12 derivations so that PNG support works

### DIFF
--- a/pills/12-inputs-design-pattern.xml
+++ b/pills/12-inputs-design-pattern.xml
@@ -56,7 +56,7 @@
       We have packaged <package>GNU hello world</package>, imagine you would like to package something else for creating at least a repository of two projects :-) . I chose <package>graphviz</package>, which uses the standard autotools build system, requires no patching and dependencies are optional.
     </para>
     <para>
-      Download <package>graphviz</package> from <link xlink:href="http://pkgs.fedoraproject.org/repo/pkgs/graphviz/graphviz-2.38.0.tar.gz/5b6a829b2ac94efcd5fa3c223ed6d3ae/graphviz-2.38.0.tar.gz">here</link>. The <filename>graphviz.nix</filename> expression is straightforward:
+      Download <package>graphviz</package> from <link xlink:href="https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/2.49.3/graphviz-2.49.3.tar.gz">here</link>. The <filename>graphviz.nix</filename> expression is straightforward:
     </para>
     <screen><xi:include href="./12/graphviz-derivation.txt" parse="text" /></screen>
     <para>
@@ -70,33 +70,28 @@
       Remember, in <filename>autotools.nix</filename> there's a <literal>buildInputs</literal> variable which gets concatenated to <literal>baseInputs</literal>.  That would be the perfect place to add a build dependency. We created that variable exactly for this reason to be overridable from package expressions.
     </para>
     <para>
-      This 2.38 version of <package>graphviz</package> has several plugins to output png. For simplicity, we will use <package>libgd</package>.
+      This 2.49 version of <package>graphviz</package> has several plugins to output png. For simplicity, we will use <package>libgd</package>.
     </para>
   </section>
   <section>
     <title>Digression about gcc and ld wrappers</title>
     <para>
-      The <package>gd</package>, <package>jpeg</package>, <package>fontconfig</package> and <package>bzip2</package> libraries (dependencies of <package>gd</package>) don't use <command>pkg-config</command> to specify which flags to pass to the compiler. Since there's no global location for libraries, we need to tell <command>gcc</command> and <command>ld</command> where to find includes and libs.
+      The <package>graphviz</package> configure script uses <command>pkg-config</command> to specify which flags to pass to the compiler. Since there's no global location for libraries, we need to tell <command>pkg-config</command> where to find pkg-config description files, in order to enable it to tell the configure script where to find headers and libraries.
     </para>
     <para>
-      The <literal>nixpkgs</literal> provides <package>gcc</package> and <package>binutils</package>, which we are currently using for our packaging. It also <link xlink:href="http://nixos.org/nixpkgs/manual/#ssec-setup-hooks">provides wrappers</link> for them which allow passing extra arguments to <command>gcc</command> and <command>ld</command>, bypassing the project build systems:
-      <itemizedlist>
-        <listitem><para><varname>NIX_CFLAGS_COMPILE</varname>: extra flags to <command>gcc</command> at compile time</para></listitem>
-        <listitem><para><varname>NIX_LDFLAGS</varname>: extra flags to <command>ld</command></para></listitem>
-      </itemizedlist>
+      In classic POSIX systems, <command>pkg-config</command> just finds the
+      <filename>.pc</filename> files of all installed libraries in system folders
+      like <filename>/usr/lib/pkgconfig</filename>, but we don't have that in
+      the nix sandbox. The nix way to educate <command>pkg-config</command> 
+      about the existence of libraries is the environment variable 
+      <varname>PKG_CONFIG_PATH</varname>.
     </para>
     <para>
       What can we do about it? We can employ the same trick we did for <varname>PATH</varname>: automatically filling the variables from <literal>buildInputs</literal>. This is the relevant snippet of <filename>setup.sh</filename>:
     </para>
     <screen><xi:include href="./12/setup-sh.txt" parse="text" /></screen>
     <para>
-      Now adding derivations to <literal>buildInputs</literal> will add their <filename>lib</filename>, <filename>include</filename> and <filename>bin</filename> paths automatically in <filename>setup.sh</filename>.
-    </para>
-    <para>
-      The <arg>-rpath</arg> flag in <command>ld</command> is needed because at runtime, the executable must use exactly that version of the library.
-    </para>
-    <para>
-      If unneeded paths are specified, the <literal>fixup</literal> phase will shrink the <literal>rpath</literal> for us!
+      Now adding derivations to <literal>buildInputs</literal> will add their <filename>lib/pkgconfig</filename> and <filename>bin</filename> paths automatically in <filename>setup.sh</filename>.
     </para>
   </section>
   <section>
@@ -106,8 +101,13 @@
     </para>
     <screen><xi:include href="./12/graphviz-gd-derivation.txt" parse="text" /></screen>
     <para>
-      Now you can create the png! Ignore any error from <package>fontconfig</package>, especially if you are in a <literal>chroot</literal>.
-
+      We add <command>pkg-config</command> to the derivation to make this tool
+      available for the configure script. As <package>gd</package> is a package
+      with <link xlink:href="https://nixos.org/manual/nixpkgs/stable/#sec-multiple-outputs-">split outputs</link>,
+      we need to add both the library- and development outputs.
+    </para>
+    <para>
+      Now you can create the png!
     </para>
   </section>
   <section>
@@ -218,7 +218,7 @@
       </itemizedlist>
     </para>
     <para>
-      You can find the whole repository at the <link xlink:href="https://gist.github.com/lethalman/734b168a0258b8a38ca2">pill 12</link> gist.
+      You can find the whole repository at the <link xlink:href="https://gist.github.com/tfc/ca800a444b029e85a14e530c25f8e872">pill 12</link> gist.
     </para>
   </section>
   <section>

--- a/pills/12/graphviz-derivation.txt
+++ b/pills/12/graphviz-derivation.txt
@@ -3,5 +3,5 @@ let
   mkDerivation = import ./autotools.nix pkgs;
 in mkDerivation {
   name = "graphviz";
-  src = ./graphviz-2.38.0.tar.gz;
+  src = ./graphviz-2.49.3.tar.gz;
 }

--- a/pills/12/graphviz-gd-derivation.txt
+++ b/pills/12/graphviz-gd-derivation.txt
@@ -3,6 +3,10 @@ let
   mkDerivation = import ./autotools.nix pkgs;
 in mkDerivation {
   name = "graphviz";
-  src = ./graphviz-2.38.0.tar.gz;
-  buildInputs = with pkgs; [ gd fontconfig libjpeg bzip2 ];
+  src = ./graphviz-2.49.3.tar.gz;
+  buildInputs = with pkgs; [
+    pkg-config
+    (pkgs.lib.getLib gd)
+    (pkgs.lib.getDev gd)
+  ];
 }

--- a/pills/12/graphviz-mkderivation.txt
+++ b/pills/12/graphviz-mkderivation.txt
@@ -1,7 +1,14 @@
-{ mkDerivation, gdSupport ? true, gd, fontconfig, libjpeg, bzip2 }:
+{ mkDerivation, lib, gdSupport ? true, gd, pkg-config }:
 
 mkDerivation {
   name = "graphviz";
-  src = ./graphviz-2.38.0.tar.gz;
-  buildInputs = if gdSupport then [ gd fontconfig libjpeg bzip2 ] else [];
+  src = ./graphviz-2.49.3.tar.gz;
+  buildInputs =
+    if gdSupport
+      then [
+          pkg-config
+          (lib.getLib gd)
+          (lib.getDev gd)
+        ]
+      else [];
 }

--- a/pills/12/repository-mkderivation.txt
+++ b/pills/12/repository-mkderivation.txt
@@ -2,10 +2,10 @@ let
   pkgs = import <nixpkgs> {};
   mkDerivation = import ./autotools.nix pkgs;
 in with pkgs; {
-  hello = import ./hello.nix { inherit mkDerivation; }; 
-  graphviz = import ./graphviz.nix { inherit mkDerivation gd fontconfig libjpeg bzip2; };
+  hello = import ./hello.nix { inherit mkDerivation; };
+  graphviz = import ./graphviz.nix { inherit mkDerivation lib gd pkg-config; };
   graphvizCore = import ./graphviz.nix {
-    inherit mkDerivation gd fontconfig libjpeg bzip2;
+    inherit mkDerivation lib gd pkg-config;
     gdSupport = false;
   };
 }

--- a/pills/12/setup-sh.txt
+++ b/pills/12/setup-sh.txt
@@ -2,10 +2,7 @@ for p in $baseInputs $buildInputs; do
   if [ -d $p/bin ]; then
     export PATH="$p/bin${PATH:+:}$PATH"
   fi
-  if [ -d $p/include ]; then
-    export NIX_CFLAGS_COMPILE="-I $p/include${NIX_CFLAGS_COMPILE:+ }$NIX_CFLAGS_COMPILE"
-  fi
-  if [ -d $p/lib ]; then
-    export NIX_LDFLAGS="-rpath $p/lib -L $p/lib${NIX_LDFLAGS:+ }$NIX_LDFLAGS"
+  if [ -d $p/lib/pkgconfig ]; then
+    export PKG_CONFIG_PATH="$p/lib/pkgconfig${PKG_CONFIG_PATH:+:}$PKG_CONFIG_PATH"
   fi
 done


### PR DESCRIPTION
This also fixes https://github.com/NixOS/nix-pills/issues/107

`graphviz`'s configure script respects the output of `pkg-config` if this tool's env vars are set correctly, so PNG does work with this change.