### PR TITLE
Fix links to nixpkgs source

### DIFF
--- a/pills/16-nixpkgs-parameters.xml
+++ b/pills/16-nixpkgs-parameters.xml
@@ -63,10 +63,10 @@
   <section>
     <title>The config parameter</title>
     <para>
-      I'm sure on the wiki or other manuals you've read about <filename>~/.nixpkgs/config.nix</filename> and I'm sure you've wondered whether that's hardcoded in nix. It's not, it's in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix#L45">nixpkgs</link>.
+      I'm sure on the wiki or other manuals you've read about <filename>~/.config/nixpkgs/config.nix</filename> (previously <filename>~/.nixpkgs/config.nix</filename>) and I'm sure you've wondered whether that's hardcoded in nix. It's not, it's in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/32c523914fdb8bf9cc7912b1eba023a8daaae2e8/pkgs/top-level/impure.nix#L28">nixpkgs</link>.
     </para>
     <para>
-      The <filename>all-packages.nix</filename> expression accepts the <literal>config</literal> parameter. If it's <literal>null</literal>, then it reads the <varname>NIXPKGS_CONFIG</varname> environment variable. If not specified, <literal>nixpkgs</literal> will peek <filename>$HOME/.nixpkgs/config.nix</filename>.
+      The <filename>all-packages.nix</filename> expression accepts the <literal>config</literal> parameter. If it's <literal>null</literal>, then it reads the <varname>NIXPKGS_CONFIG</varname> environment variable. If not specified, <literal>nixpkgs</literal> will peek <filename>$HOME/.config/nixpkgs/config.nix</filename>.
     </para>
     <para>
       After determining <filename>config.nix</filename>, it will be imported as nix expression, and that will be the value of <literal>config</literal> (in case it hasn't been passed as parameter to import <literal>&lt;nixpkgs&gt;</literal>).

--- a/pills/17-nixpkgs-overriding-packages.xml
+++ b/pills/17-nixpkgs-overriding-packages.xml
@@ -108,12 +108,12 @@
     </para>
   </section>
   <section>
-    <title>The ~/.nixpkgs/config.nix file</title>
+    <title>The ~/.config/nixpkgs/config.nix file</title>
     <para>
-      In the previous pill we already talked about this file. The above <filename>config.nix</filename> that we just wrote could be the content of <filename>~/.nixpkgs/config.nix</filename>.
+      In the previous pill we already talked about this file. The above <filename>config.nix</filename> that we just wrote could be the content of <filename>~/.config/nixpkgs/config.nix</filename> (or the deprecated location <filename>~/.nixpkgs/config.nix</filename>).
     </para>
     <para>
-      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/pkgs/top-level/all-packages.nix#L54">imported by nixpkgs</link>.
+      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/32c523914fdb8bf9cc7912b1eba023a8daaae2e8/pkgs/top-level/impure.nix#L28">imported by nixpkgs</link>.
     </para>
   </section>
   <section>

--- a/pills/17-nixpkgs-overriding-packages.xml
+++ b/pills/17-nixpkgs-overriding-packages.xml
@@ -47,7 +47,7 @@
       The fixed point with lazy evaluation is crippling but about necessary in a language like Nix. It lets us achieve something similar to what we'd do imperatively.
     </para>
     <para>
-      Follows the definition of fixed point in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/master/lib/trivial.nix#L21">nixpkgs</link>:
+      Follows the definition of fixed point in <link xlink:href="https://github.com/NixOS/nixpkgs/blob/f224a4f1b32b3e813783d22de54e231cd8ea2448/lib/fixed-points.nix#L19">nixpkgs</link>:
     </para>
     <screen><xi:include href="./17/fix-function.txt" parse="text" /></screen>
     <para>
@@ -113,7 +113,7 @@
       In the previous pill we already talked about this file. The above <filename>config.nix</filename> that we just wrote could be the content of <filename>~/.config/nixpkgs/config.nix</filename> (or the deprecated location <filename>~/.nixpkgs/config.nix</filename>).
     </para>
     <para>
-      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/32c523914fdb8bf9cc7912b1eba023a8daaae2e8/pkgs/top-level/impure.nix#L28">imported by nixpkgs</link>.
+      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/f224a4f1b32b3e813783d22de54e231cd8ea2448/lib/fixed-points.nix#L19">imported by nixpkgs</link>.
     </para>
   </section>
   <section>


### PR DESCRIPTION
* Fix [link to config.nix](https://github.com/NixOS/nixpkgs/blob/32c523914fdb8bf9cc7912b1eba023a8daaae2e8/pkgs/top-level/impure.nix#L28) in source, and update the path to ~/.config/nixpkgs/config.nix. Link to today's permalink at github instead of master. When this was originally written, ~/.nixpkgs/config.nix was loaded by all-packages.nix. But this was moved to pkgs/top-level/default.nix (https://github.com/NixOS/nixpkgs/commit/ad317834053983e1bf3b61f58c923ca48a0dd2d7 ) and then to pkgs/top-level/impure.nix (https://github.com/NixOS/nixpkgs/commit/4af2bf66631d187d952b70fba4963e33002d1dcb)
* Fix [link to fix function](https://github.com/NixOS/nixpkgs/blob/f224a4f1b32b3e813783d22de54e231cd8ea2448/lib/fixed-points.nix#L19) in nixpkgs source. Link to today's permalink at github instead of master. The fix function was moved from trivial.nix to fixed-points.nix (https://github.com/NixOS/nixpkgs/commit/87b4a91fc4145e04ca028c08754bd144b8d1d02d)