### PR TITLE
Fix link to reference to config.nix again

### DIFF
--- a/pills/17-nixpkgs-overriding-packages.xml
+++ b/pills/17-nixpkgs-overriding-packages.xml
@@ -113,7 +113,7 @@
       In the previous pill we already talked about this file. The above <filename>config.nix</filename> that we just wrote could be the content of <filename>~/.config/nixpkgs/config.nix</filename> (or the deprecated location <filename>~/.nixpkgs/config.nix</filename>).
     </para>
     <para>
-      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/f224a4f1b32b3e813783d22de54e231cd8ea2448/lib/fixed-points.nix#L19">imported by nixpkgs</link>.
+      Instead of passing it explicitly whenever we import <literal>nixpkgs</literal>, it will be automatically <link xlink:href="https://github.com/NixOS/nixpkgs/blob/32c523914fdb8bf9cc7912b1eba023a8daaae2e8/pkgs/top-level/impure.nix#L28">imported by nixpkgs</link>.
     </para>
   </section>
   <section>


### PR DESCRIPTION
In 2815ca0fab63b1a93be6417ff77822e530c4ddfe (#197) I accidentally changed a config.nix link (which I fixed in the previous commit ddd0a63dac83f766a63e10096eabb7b85024654c) to point to the `fix` definition instead. This commit reverts that part of the commit. Sorry.