### PR TITLE
Fix bug in the generic-builder.txt file of Pill 8

### DIFF
--- a/pills/08/autotools-nix.txt
+++ b/pills/08/autotools-nix.txt
@@ -3,8 +3,8 @@ pkgs: attrs:
   let defaultAttrs = {
     builder = "${bash}/bin/bash";
     args = [ ./builder.sh ];
-    baseInputs = [ gnutar gzip gnumake gcc coreutils gawk gnused gnugrep binutils.bintools ];
-    buildInputs = [];
+    buildInputs = [ gnutar gzip gnumake gcc coreutils gawk gnused gnugrep binutils.bintools ];
+    baseInputs = [];
     system = builtins.currentSystem;
   };
   in

--- a/pills/08/autotools-nix.txt
+++ b/pills/08/autotools-nix.txt
@@ -3,8 +3,8 @@ pkgs: attrs:
   let defaultAttrs = {
     builder = "${bash}/bin/bash";
     args = [ ./builder.sh ];
-    buildInputs = [ gnutar gzip gnumake gcc coreutils gawk gnused gnugrep binutils.bintools ];
-    baseInputs = [];
+    baseInputs = [ gnutar gzip gnumake gcc coreutils gawk gnused gnugrep binutils.bintools ];
+    buildInputs = [];
     system = builtins.currentSystem;
   };
   in

--- a/pills/08/generic-builder.txt
+++ b/pills/08/generic-builder.txt
@@ -1,6 +1,6 @@
 set -e
 unset PATH
-for p in $buildInputs; do
+for p in $baseInputs; do
   export PATH=$p/bin${PATH:+:}$PATH
 done
 


### PR DESCRIPTION
Under this section: https://nixos.org/guides/nix-pills/generic-builders.html#idm140737320224432

There is a loop over `buildInputs` like this:
```
for p in $buildInputs; do
  export PATH=$p/bin${PATH:+:}$PATH
done
```

but `buildInputs`, which is defined in `autotools.nix`, is empty, resulting in an empty PATH. This PR fixes that typo so that it iterates over `$baseInputs` instead.