### PR TITLE
Fix darwin hello example

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -50,7 +50,9 @@
     <screen><xi:include href="./08/hello-nix.txt" parse="text" /></screen>
     <note><title>Nix on darwin</title>
     <para>Darwin (i.e. macOS) builds typically use <literal>clang</literal> rather than <literal>gcc</literal> for a C compiler.
-    We can adapt this early example for darwin by using this modified version of <filename>hello.nix</filename>:
+    Additionally, <literal>codesign_allocate<literal> tool is required to be present in PATH.
+    We can adapt this early example for darwin by using this modified version of <filename>hello_builder.sh</filename> and <filename>hello.nix</filename>:
+    <screen><xi:include href="./08/hello-builder-darwin.txt" parse="text" /></screen>
     <screen><xi:include href="./08/hello-nix-darwin.txt" parse="text" /></screen>
     Later, we will show how Nix can automatically handle these differences.
     For now, please be just aware that changes similar to the above may be needed in what follows.

--- a/pills/08/hello-builder-darwin.txt
+++ b/pills/08/hello-builder-darwin.txt
@@ -1,0 +1,6 @@
+export PATH="$gnutar/bin:$gcc/bin:$gnumake/bin:$coreutils/bin:$gawk/bin:$gzip/bin:$gnugrep/bin:$gnused/bin:$bintools/bin:$cctools/bin"
+tar -xzf $src
+cd hello-2.10
+./configure --prefix=$out
+make
+make install

--- a/pills/08/hello-nix-darwin.txt
+++ b/pills/08/hello-nix-darwin.txt
@@ -4,6 +4,7 @@ derivation {
   builder = "${bash}/bin/bash";
   args = [ ./hello_builder.sh ];
   inherit gnutar gzip gnumake coreutils gawk gnused gnugrep;
+  cctools = darwin.cctools;
   gcc = clang;
   binutils = clang.bintools.bintools_bin;
   src = ./hello-2.10.tar.gz;


### PR DESCRIPTION
When compiling the hello example on Darwin (macOS), codesign_allocate is required to be in PATH. Otherwise `configure` will report an error that cc failed to produce a binary (see the log below). This adds darwin.cctools to PATH, which solves this problem.

```
configure:4014: checking whether the C compiler works
configure:4036: cc    conftest.c  >&5
libc++abi: terminating with uncaught exception of type std::runtime_error: Failed to spawn codesign_allocate: No such file or directory
/nix/store/xr3ajrx1wqy12bapwmmp4djk4cczka1s-post-link-sign-hook: line 4: 12019 Abort trap: 6           CODESIGN_ALLOCATE=codesign_allocate /nix/store/8w17sv1ibalci18ysz93zyd4k536vbhl-sigtool-0.1.3/bin/codesign -f -s - "$linkerOutput"
clang-11: error: linker command failed with exit code 134 (use -v to see invocation)
```