### PR TITLE
Pill 8: fix Darwin reference to binutils

### DIFF
--- a/pills/08/hello-nix-darwin.txt
+++ b/pills/08/hello-nix-darwin.txt
@@ -5,7 +5,7 @@ derivation {
   args = [ ./hello_builder.sh ];
   inherit gnutar gzip gnumake coreutils gawk gnused gnugrep;
   gcc = clang;
-  binutils = clang.bintools.bintools_bin;
+  bintools = clang.bintools.bintools_bin;
   src = ./hello-2.10.tar.gz;
   system = builtins.currentSystem;
 }


### PR DESCRIPTION
The Darwin nix still assigns to `binutils`, even though the builder itself was updated to point to `bintools` in ce931b9697343dc781b004834c496edd28b52186. Fixing this ensures the hello example actually builds on Darwin.