### PR TITLE
Pill 17: fix graphviz xorg override

### DIFF
--- a/pills/17/config-nix.txt
+++ b/pills/17/config-nix.txt
@@ -1,5 +1,5 @@
 {
   packageOverrides = pkgs: {
-    graphviz = pkgs.graphviz.override { xorg = null; };
+    graphviz = pkgs.graphviz.override { withXorg = false; };
   };
 }

--- a/pills/17/graphviz-override.txt
+++ b/pills/17/graphviz-override.txt
@@ -1,4 +1,4 @@
 $ nix repl
 nix-repl> :l <nixpkgs>
 Added 4360 variables.
-nix-repl> :b graphviz.override { xorg = null; }
+nix-repl> :b graphviz.override { withXorg = false; }

--- a/pills/17/p-graphviz-override.txt
+++ b/pills/17/p-graphviz-override.txt
@@ -1,3 +1,3 @@
 pkgs = import <nixpkgs> {};
-pkgs.graphviz = pkgs.graphviz.override { xorg = null; };
+pkgs.graphviz = pkgs.graphviz.override { withXorg = false; };
 build(pkgs.P)


### PR DESCRIPTION
In the current version of nix, overriding `xorg = null;` no longer seems to work; overriding the `withXorg` attribute allowed it to pass for me instead.