### PR TITLE
with removed from first line

### DIFF
--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -307,7 +307,7 @@
       <varname>coreutils</varname>.
     </para>
     <para>
-      Below is a revised version of the <filename>simple.nix</filename> file, using the inherit keyword:
+      Below is a revised version of the <filename>simple.nix</filename> file, using the <code>inherit</code> keyword:
 
       <programlisting><xi:include href="./07/simple_inherit.txt" parse="text" /></programlisting>
 

--- a/pills/07-working-derivation.xml
+++ b/pills/07-working-derivation.xml
@@ -307,10 +307,15 @@
       <varname>coreutils</varname>.
     </para>
     <para>
-      Then we meet the
+      Below is a revised version of the <filename>simple.nix</filename> file, using the inherit keyword:
+
+      <programlisting><xi:include href="./07/simple_inherit.txt" parse="text" /></programlisting>
+
+      Here we also take the opportunity to introduce the
       <link xlink:href="https://nixos.org/manual/nix/stable/expressions/language-constructs.html#inheriting-attributes"><code>inherit</code> keyword</link>.
       <code>inherit foo;</code> is equivalent to <code>foo = foo;</code>.
-      Similarly, <code>inherit foo bar;</code> is equivalent to <code>foo = foo; bar = bar;</code>.
+      Similarly, <code>inherit gcc coreutils;</code> is equivalent to <code> gcc = gcc; coreutils = coreutils;</code>.
+      Lastly, <code>inherit (pkgs) gcc coreutils;</code> is equivalent to <code> gcc = pkgs.gcc; coreutils = pkgs.coreutils;</code>.
     </para>
     <para>
       This syntax only makes sense inside sets. There's no magic involved, it's

--- a/pills/07/simple.txt
+++ b/pills/07/simple.txt
@@ -1,9 +1,12 @@
-with (import <nixpkgs> {});
-derivation {
-  name = "simple";
-  builder = "${bash}/bin/bash";
-  args = [ ./simple_builder.sh ];
-  inherit gcc coreutils;
-  src = ./simple.c;
-  system = builtins.currentSystem;
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.stdenv.mkDerivation {
+    name = "simple";
+    builder = "${pkgs.bash}/bin/bash";
+    args = [ ./simple_builder.sh ];
+    gcc = pkgs.gcc;
+    coreutils = pkgs.coreutils;
+    src = ./simple.c;
+    system = builtins.currentSystem;
 }

--- a/pills/07/simple_inherit.txt
+++ b/pills/07/simple_inherit.txt
@@ -1,12 +1,11 @@
 let
   pkgs = import <nixpkgs> {};
-  inherit (pkgs) gcc coreutils;
 in
   pkgs.stdenv.mkDerivation {
     name = "simple";
     builder = "${pkgs.bash}/bin/bash";
     args = [ ./simple_builder.sh ];
-    inherit gcc coreutils;
+    inherit (pkgs) gcc coreutils;
     src = ./simple.c;
     system = builtins.currentSystem;
 }

--- a/pills/07/simple_inherit.txt
+++ b/pills/07/simple_inherit.txt
@@ -1,0 +1,12 @@
+let
+  pkgs = import <nixpkgs> {};
+  inherit (pkgs) gcc coreutils;
+in
+  pkgs.stdenv.mkDerivation {
+    name = "simple";
+    builder = "${pkgs.bash}/bin/bash";
+    args = [ ./simple_builder.sh ];
+    inherit gcc coreutils;
+    src = ./simple.c;
+    system = builtins.currentSystem;
+}


### PR DESCRIPTION
Nix example file no longer starts with with (import <nixpkgs> {});

It's an attempt to better follow style guidelines for how to write nix expressions.