### PR TITLE
fix(typo): rename mymkDerivation to mkDerivation in Conclusion of pill 08

### DIFF
--- a/pills/08-generic-builders.xml
+++ b/pills/08-generic-builders.xml
@@ -297,7 +297,7 @@
 
     <para>
       Out of this pill we managed to create a generic builder for autotools
-      projects, and a function <code>mymkDerivation</code> that composes by default
+      projects, and a function <code>mkDerivation</code> that composes by default
       the common components used in autotools projects instead of repeating them
       in all the packages we would write.
     </para>


### PR DESCRIPTION
Hi,

In Conclusion of pill 08 `mymkDerivation` is mentioned as a function that was created. I believe it should be changed to `mkDerivation` - that's the name declared in code [here](https://github.com/NixOS/nix-pills/blob/master/pills/08/hello-nix-rev-2.txt#L3C3-L3C15):

```nix
  mkDerivation = import ./autotools.nix pkgs;
```

Also, `mkDerivation`  is mentioned earlier in the pill [here](https://github.com/NixOS/nix-pills/blob/master/pills/08-generic-builders.xml#L266)