### PR TITLE
show-derivation -> derivation show

### DIFF
--- a/pills/06/examine-build.xml
+++ b/pills/06/examine-build.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation /nix/store/qyfrcd53wmc0v22ymhhd5r6sz5xmdc8a-<emphasis>myname.drv</emphasis></userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show /nix/store/qyfrcd53wmc0v22ymhhd5r6sz5xmdc8a-<emphasis>myname.drv</emphasis></userinput>
 <computeroutput>{
   "/nix/store/qyfrcd53wmc0v22ymhhd5r6sz5xmdc8a-myname.drv": {
     "outputs": {

--- a/pills/06/show-derivation.xml
+++ b/pills/06/show-derivation.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation /nix/store/z3hhlxbckx4g3n9sw91nnvlkjvyw754p-<emphasis>myname.drv</emphasis></userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show /nix/store/z3hhlxbckx4g3n9sw91nnvlkjvyw754p-<emphasis>myname.drv</emphasis></userinput>
 <computeroutput>{
   "/nix/store/z3hhlxbckx4g3n9sw91nnvlkjvyw754p-myname.drv": {
     "outputs": {

--- a/pills/07/foo.drv.xml
+++ b/pills/07/foo.drv.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis></userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-<emphasis>foo.drv</emphasis></userinput>
 <computeroutput>{
   "/nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-foo.drv": {
     "outputs": {

--- a/pills/18/bar-derivation.xml
+++ b/pills/18/bar-derivation.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation /nix/store/ymsf5zcqr9wlkkqdjwhqllgwa97rff5i-<emphasis>bar.drv</emphasis></userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show /nix/store/ymsf5zcqr9wlkkqdjwhqllgwa97rff5i-<emphasis>bar.drv</emphasis></userinput>
 <computeroutput>{
   "/nix/store/ymsf5zcqr9wlkkqdjwhqllgwa97rff5i-bar.drv": {
     "outputs": {

--- a/pills/18/derivation-simple-content.xml
+++ b/pills/18/derivation-simple-content.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation /nix/store/y4h73bmrc9ii5bxg6i7ck6hsf5gqv8ck-<emphasis>foo.drv</emphasis></userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show /nix/store/y4h73bmrc9ii5bxg6i7ck6hsf5gqv8ck-<emphasis>foo.drv</emphasis></userinput>
 <computeroutput>{
   "/nix/store/y4h73bmrc9ii5bxg6i7ck6hsf5gqv8ck-foo.drv": {
     "outputs": {

--- a/pills/19/hello-derivation.xml
+++ b/pills/19/hello-derivation.xml
@@ -1,4 +1,4 @@
-<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix show-derivation $(nix-instantiate hello.nix)</userinput>
+<screen xmlns="http://docbook.org/ns/docbook"><prompt>$ </prompt><userinput>nix derivation show $(nix-instantiate hello.nix)</userinput>
 <computeroutput>warning: you did not specify '--add-root'; the result might be removed by the garbage collector
 {
   "/nix/store/abwj50lycl0m515yblnrvwyydlhhqvj2-hello.drv": {


### PR DESCRIPTION
It looks like the command `nix show-derivation` is deprecated in favor of `nix derivation show` .
This replaces all instances of `show-derivation` with `derivation show`