### PR TITLE
removing broken link for writing expressions

### DIFF
--- a/pills/02-install-on-your-running.xml
+++ b/pills/02-install-on-your-running.xml
@@ -192,10 +192,9 @@
     parse="text" /></screen>
 
     <para>
-      <link
-          xlink:href="https://nixos.org/manual/nix/stable/expressions/writing-nix-expressions.html">Nix
-      expressions</link> are used to describe packages and how to
-      build them. <link
+      Nix expressions are written in the <link 
+      xlink:href="https://nix.dev/tutorials/nix-language">Nix language</link> and used to 
+      describe packages and how to build them. <link 
       xlink:href="https://nixos.org/nixpkgs/">Nixpkgs</link> is the
       repository containing all of the expressions: <link
       xlink:href="https://github.com/NixOS/nixpkgs">https://github.com/NixOS/nixpkgs</link>.


### PR DESCRIPTION
Replacing with nix.dev language basics link.
(not a 100% substitute)

Trying to address  #226 but of course open for other suggestions as well.