### PR TITLE
07-working-derivation.md: use `derivation` instead of `mkDerivation`

### DIFF
--- a/pills/07-working-derivation.md
+++ b/pills/07-working-derivation.md
@@ -189,7 +189,7 @@ Drop out of nix repl and write a file `simple.nix`:
 let
   pkgs = import <nixpkgs> { };
 in
-pkgs.stdenv.mkDerivation {
+derivation {
   name = "simple";
   builder = "${pkgs.bash}/bin/bash";
   args = [ ./simple_builder.sh ];
@@ -222,7 +222,7 @@ Below is a revised version of the `simple.nix` file, using the `inherit` keyword
 let
   pkgs = import <nixpkgs> { };
 in
-pkgs.stdenv.mkDerivation {
+derivation {
   name = "simple";
   builder = "${pkgs.bash}/bin/bash";
   args = [ ./simple_builder.sh ];


### PR DESCRIPTION
When switching from the nix repl to a nix file, `derivation` was replaced with `pkgs.stdenv.mkDerivation`. This was not explained, and the examples work fine without this. It seems to me that when learning that you can define the derivation in a nix file instead of in the repl, there's no need to add another change.

I see that the next chapter uses plain `derivation` in the first examples, and then defines a new function `mkDerivation`. So I'm pretty certain that we should just use plain `derivation` here.