### PR TITLE
Update 07-working-derivation.md - "input derivations" -> "input sources"

### DIFF
--- a/pills/07-working-derivation.md
+++ b/pills/07-working-derivation.md
@@ -132,7 +132,7 @@ $ nix derivation show /nix/store/i76pr1cz0za3i9r6xq518bqqvd2raspw-foo.drv
 }
 ```
 
-Much like the usual .drv, except that there's a list of arguments in there passed to the builder (bash) with `builder.sh`... In the nix store..? Nix automatically copies files or directories needed for the build into the store to ensure that they are not changed during the build process and that the deployment is stateless and independent of the building machine. `builder.sh` is not only in the arguments passed to the builder, it's also in the input derivations.
+Much like the usual .drv, except that there's a list of arguments in there passed to the builder (bash) with `builder.sh`... In the nix store..? Nix automatically copies files or directories needed for the build into the store to ensure that they are not changed during the build process and that the deployment is stateless and independent of the building machine. `builder.sh` is not only in the arguments passed to the builder, it's also in the input sources.
 
 Given that `builder.sh` is a plain file, it has no .drv associated with it. The store path is computed based on the filename and on the hash of its contents. Store paths are covered in detail in [a later pill](18-nix-store-paths.md).
 


### PR DESCRIPTION
The text says that `builder.sh` is in the input derivations. It's actually in `inputSrcs`, not `inputDrvs`. Perhaps in the past there was just one list?