### PR TITLE
Update 09-automatic-runtime-dependencies.md - fix NixOps link

### DIFF
--- a/pills/09-automatic-runtime-dependencies.md
+++ b/pills/09-automatic-runtime-dependencies.md
@@ -131,7 +131,7 @@ Of course, the executable will run fine as long as everything is under the `/nix
 
 We saw some of the tools Nix provides, along with their features. In particular, we saw how Nix is able to compute runtime dependencies automatically. This is not limited to only shared libraries, but can also reference executables, scripts, Python libraries, and so forth.
 
-Approaching builds in this way makes packages self-contained, ensuring (apart from data and configuration) that copying the runtime closure onto another machine is sufficient to run the program. This enables us to run programs without installation using `nix-shell`, and forms the basis for [reliable deployment in the cloud](https://nixos.org/manual/nix/stable/introduction.html).
+Approaching builds in this way makes packages self-contained, ensuring (apart from data and configuration) that copying the runtime closure onto another machine is sufficient to run the program. This enables us to run programs without installation using `nix-shell`, and forms the basis for [reliable deployment in the cloud](https://github.com/NixOS/nixops).
 
 ## Next pill
 


### PR DESCRIPTION
The link to NixOps was corrupted by mistake in this PR: https://github.com/NixOS/nix-pills/pull/181/files#diff-a53cbc0f08ac225fd5073d54147a9a6ba2ebbdbd0e5164711ab362d0439cc27aR265

It was changed by mistake from http://nixos.org/nixops/manual/#chap-introduction to https://nixos.org/manual/nix/stable/introduction.html.

I think that at least for now, it would be better to link to https://github.com/NixOS/nixops, as the old link just links to an obscure in-development HTML document, and the github link starts with a warning "NixOps is in low-maintenance mode and probably not suited for new projects. Use at your own risks", and also links to an experimental NixOps4.