### PR TITLE
13-callpackage-design-pattern.md: no need for `with nixpkgs`

### DIFF
--- a/pills/13-callpackage-design-pattern.md
+++ b/pills/13-callpackage-design-pattern.md
@@ -131,7 +131,7 @@ let
       f = import path;
     in
     f ((builtins.intersectAttrs (builtins.functionArgs f) allPkgs) // overrides);
-  pkgs = with nixpkgs; {
+  pkgs = {
     mkDerivation = import ./autotools.nix nixpkgs;
     hello = callPackage ./hello.nix { };
     graphviz = callPackage ./graphviz.nix { };


### PR DESCRIPTION
The original code had `with nixpkgs`, but with the callPackage pattern, actually nothing from nixpkgs is used, so the `with nixpkgs` can be removed.