### PR TITLE
Fix link to functions manual

### DIFF
--- a/pills/05-functions-and-imports.md
+++ b/pills/05-functions-and-imports.md
@@ -2,7 +2,7 @@
 
 Welcome to the fifth Nix pill. In the previous [fourth pill](04-basics-of-language.md) we touched the Nix language for a moment. We introduced basic types and values of the Nix language, and basic expressions such as `if`, `with` and `let`. I invite you to re-read about these expressions and play with them in the repl.
 
-Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nix.dev/tutorials/nix-language.html#functions). Let's go: pill on one hand, Nix manual on the other hand.
+Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nix.dev/manual/nix/latest/language/constructs#functions). Let's go: pill on one hand, Nix manual on the other hand.
 
 I remind you how to enter the Nix environment: `source ~/.nix-profile/etc/profile.d/nix.sh`
 

--- a/pills/05-functions-and-imports.md
+++ b/pills/05-functions-and-imports.md
@@ -2,7 +2,7 @@
 
 Welcome to the fifth Nix pill. In the previous [fourth pill](04-basics-of-language.md) we touched the Nix language for a moment. We introduced basic types and values of the Nix language, and basic expressions such as `if`, `with` and `let`. I invite you to re-read about these expressions and play with them in the repl.
 
-Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nixos.org/manual/nix/stable/expressions/language-constructs.html#functions). Let's go: pill on one hand, Nix manual on the other hand.
+Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nix.dev/tutorials/nix-language.html#functions). Let's go: pill on one hand, Nix manual on the other hand.
 
 I remind you how to enter the Nix environment: `source ~/.nix-profile/etc/profile.d/nix.sh`
 


### PR DESCRIPTION
There is an incorrect URL to the functions manual on page https://nixos.org/guides/nix-pills/05-functions-and-imports

![image](https://github.com/NixOS/nix-pills/assets/5544994/9d0422ea-c757-47ad-8054-77b65e768ac6)


This PR fixes it 