### PR TITLE
Fix and update links to Nix manual

### DIFF
--- a/pills/02-install-on-your-running-system.md
+++ b/pills/02-install-on-your-running-system.md
@@ -4,7 +4,7 @@ Welcome to the second Nix pill. In the [first](01-why-you-should-give-it-a-try.m
 
 Now we'll install Nix on our running system and understand what changed in our system after the installation. **If you're using NixOS, Nix is already installed; you can skip to the [next](03-enter-environment.md) pill.**
 
-For installation instructions, please refer to the Nix Reference Manual on [ Installing Nix](https://nixos.org/manual/nix/stable/installation/installing-binary.html).
+For installation instructions, please refer to the Nix Reference Manual on [Installing Nix](https://nix.dev/manual/nix/stable/installation/installing-binary).
 
 ## Installation
 
@@ -14,7 +14,7 @@ The first thing to note: derivations in the Nix store refer to other derivations
 
 <div class="info">
 
-Note: In a multi-user installation, such as the one used in NixOS, the store is owned by root and multiple users can install and build software through a Nix daemon. You can read more about multi-user installations here: <https://nixos.org/manual/nix/stable/installation/installing-binary.html#multi-user-installation>.
+Note: In a multi-user installation, such as the one used in NixOS, the store is owned by root and multiple users can install and build software through a Nix daemon. You can read more about [multi-user installations here](https://nix.dev/manual/nix/stable/installation/installing-binary#multi-user-installation).
 
 </div>
 
@@ -60,7 +60,7 @@ Important: Never change `/nix/store` manually. If you do, then it will no longer
 
 ## The first profile
 
-Next in the installation, we encounter the concept of the [profile](https://nixos.org/manual/nix/stable/package-management/profiles.html):
+Next in the installation, we encounter the concept of the [profile](https://nix.dev/manual/nix/stable/package-management/profiles):
 
 <pre><code class="hljs">creating /home/nix/.nix-profile
 installing 'nix-2.1.3'

--- a/pills/03-enter-environment.md
+++ b/pills/03-enter-environment.md
@@ -36,7 +36,7 @@ Now you can run `hello`. Things to notice:
 
 - It created a new user environment. That's a new generation of our Nix user profile.
 
-- The [nix-env](https://nixos.org/manual/nix/stable/command-ref/nix-env.html) tool manages environments, profiles and their generations.
+- The [nix-env](https://nix.dev/manual/nix/stable/command-ref/nix-env) tool manages environments, profiles and their generations.
 
 - We installed `hello` by derivation name minus the version. I repeat: we specified the **derivation name** (minus the version) to install it.
 
@@ -62,7 +62,7 @@ So, where did `hello` really get installed? `which hello` is `~/.nix-profile/bin
 
 At this point you probably want to run `man` to get some documentation. Even if you already have man system-wide outside of the Nix environment, you can install and use it within Nix with `nix-env -i man-db`. As usual, a new generation will be created, and `~/.nix-profile` will point to it.
 
-Let's inspect the [profile](https://nixos.org/manual/nix/stable/package-management/profiles.html) a bit:
+Let's inspect the [profile](https://nix.dev/manual/nix/stable/package-management/profiles) a bit:
 
 ```console
 $ ls -l ~/.nix-profile/
@@ -106,7 +106,7 @@ switching from generation 2 to 3
 
 I invite you to read the manpage of `nix-env`. `nix-env` requires an operation to perform, then there are common options for all operations, as well as options specific to each operation.
 
-You can of course also [ uninstall](https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---uninstall) and [upgrade](https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---upgrade) packages.
+You can of course also [uninstall](https://nix.dev/manual/nix/stable/command-ref/nix-env/uninstall) and [upgrade](https://nix.dev/manual/nix/stable/command-ref/nix-env/upgrade) packages.
 
 ## Querying the store
 
@@ -196,7 +196,7 @@ $ /nix/store/ig31y9gfpp8pf3szdd7d4sf29zr7igbr-nix-2.1.3/bin/nix-env -i /nix/stor
 
 ## Channels
 
-So where are we getting packages from? We said something about this already in the [second article](02-install-on-your-running-system.md). There's a list of channels from which we get packages, although usually we use a single channel. The tool to manage channels is [nix-channel](https://nixos.org/manual/nix/stable/command-ref/nix-channel.html).
+So where are we getting packages from? We said something about this already in the [second article](02-install-on-your-running-system.md). There's a list of channels from which we get packages, although usually we use a single channel. The tool to manage channels is [nix-channel](https://nix.dev/manual/nix/stable/command-ref/nix-channel).
 
 ```console
 $ nix-channel --list
@@ -219,7 +219,7 @@ This is quite similar to `apt-get update`. (See [this table](https://wiki.nixos.
 
 ## Conclusion
 
-We learned how to query the user environment and to manipulate it by installing and uninstalling software. Upgrading software is also straightforward, as you can read in [the manual](https://nixos.org/manual/nix/stable/command-ref/nix-env.html#operation---upgrade) (`nix-env -u` will upgrade all packages in the environment).
+We learned how to query the user environment and to manipulate it by installing and uninstalling software. Upgrading software is also straightforward, as you can read in [the manual](https://nix.dev/manual/nix/stable/command-ref/nix-env/upgrade) (`nix-env -u` will upgrade all packages in the environment).
 
 Every time we change the environment, a new generation is created. Switching between generations is easy and immediate.
 

--- a/pills/04-basics-of-language.md
+++ b/pills/04-basics-of-language.md
@@ -2,7 +2,7 @@
 
 Welcome to the fourth Nix pill. In the [previous article](03-enter-environment.md) we learned about Nix environments. We installed software as a user, managed their profile, switched between generations, and queried the Nix store. Those are the very basics of system administration using Nix.
 
-The [Nix language](https://nixos.org/manual/nix/stable/expressions/expression-language.html) is used to write expressions that produce derivations. The [nix-build](https://nixos.org/manual/nix/stable/command-ref/nix-build.html) tool is used to build derivations from an expression. Even as a system administrator that wants to customize the installation, it's necessary to master Nix. Using Nix for your jobs means you get the features we saw in the previous articles for free.
+The [Nix language](https://nix.dev/manual/nix/stable/language/) is used to write expressions that produce derivations. The [nix-build](https://nix.dev/manual/nix/stable/command-ref/nix-build) tool is used to build derivations from an expression. Even as a system administrator that wants to customize the installation, it's necessary to master Nix. Using Nix for your jobs means you get the features we saw in the previous articles for free.
 
 The syntax of Nix is quite unfamiliar, so looking at existing examples may lead you to think that there's a lot of magic happening. In reality, it's mostly about writing utility functions to make things convenient.
 
@@ -22,7 +22,7 @@ Important: Values in Nix are immutable.
 
 ## Value types
 
-Nix 2.0 contains a command named `nix repl` which is a simple command line tool for playing with the Nix language. In fact, Nix is a [pure, lazy, functional language](https://nixos.org/manual/nix/stable/expressions/expression-language.html), not only a set of tools to manage derivations. The `nix repl` syntax is slightly different to Nix syntax when it comes to assigning variables, but it shouldn't be confusing so long as you bear it in mind. I prefer to start with `nix repl` before cluttering your mind with more complex expressions.
+Nix 2.0 contains a command named `nix repl` which is a simple command line tool for playing with the Nix language. In fact, Nix is a [pure, lazy, functional language](https://nix.dev/manual/nix/stable/language/), not only a set of tools to manage derivations. The `nix repl` syntax is slightly different to Nix syntax when it comes to assigning variables, but it shouldn't be confusing so long as you bear it in mind. I prefer to start with `nix repl` before cluttering your mind with more complex expressions.
 
 Launch `nix repl`. First of all, Nix supports basic arithmetic operations: `+`, `-`, `*` and `/`. (To exit `nix repl`, use the command `:q`. Help is available through the `:?` command.)
 
@@ -56,7 +56,7 @@ nix-repl> builtins.div 6 3
 
 Other operators are `||`, `&&` and `!` for booleans, and relational operators such as `!=`, `==`, `<`, `>`, `<=`, `>=`. In Nix, `<`, `>`, `<=` and `>=` are not much used. There are also other operators we will see in the course of this series.
 
-Nix has integer, floating point, string, path, boolean and null [simple](https://nixos.org/manual/nix/stable/expressions/language-values.html) types. Then there are also lists, sets and functions. These types are enough to build an operating system.
+Nix has integer, floating point, string, path, boolean and null [simple](https://nix.dev/manual/nix/stable/language/#overview) types. Then there are also lists, sets and functions. These types are enough to build an operating system.
 
 Nix is strongly typed, but it's not statically typed. That is, you cannot mix strings and integers, you must first do the conversion.
 
@@ -90,7 +90,7 @@ nix-repl> ''foo''
 
 In other languages like Python you can also use single quotes for strings (e.g. `'foo'`), but not in Nix.
 
-It's possible to [interpolate](https://nixos.org/manual/nix/stable/expressions/language-values.html) whole Nix expressions inside strings with the `${...}` syntax and only that syntax, not `$foo` or `{$foo}` or anything else.
+It's possible to [interpolate](https://nix.dev/manual/nix/stable/language/string-interpolation) whole Nix expressions inside strings with the `${...}` syntax and only that syntax, not `$foo` or `{$foo}` or anything else.
 
 ```console
 nix-repl> foo = "strval"
@@ -165,7 +165,7 @@ nix-repl> { a = 3; b = a+4; }
 error: undefined variable `a' at (string):1:10
 ```
 
-To do so, use [recursive attribute sets](https://nixos.org/manual/nix/stable/expressions/language-constructs.html#recursive-sets):
+To do so, use [recursive attribute sets](https://nix.dev/manual/nix/stable/language/constructs#recursive-sets):
 
 ```console
 nix-repl> rec { a = 3; b = a+4; }

--- a/pills/05-functions-and-imports.md
+++ b/pills/05-functions-and-imports.md
@@ -2,7 +2,7 @@
 
 Welcome to the fifth Nix pill. In the previous [fourth pill](04-basics-of-language.md) we touched the Nix language for a moment. We introduced basic types and values of the Nix language, and basic expressions such as `if`, `with` and `let`. I invite you to re-read about these expressions and play with them in the repl.
 
-Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nixos.org/manual/nix/stable/expressions/language-constructs.html#functions). Let's go: pill on one hand, Nix manual on the other hand.
+Functions help to build reusable components in a big repository like [nixpkgs](https://github.com/NixOS/nixpkgs/). The Nix manual has a [great explanation of functions](https://nix.dev/manual/nix/stable/language/constructs#functions). Let's go: pill on one hand, Nix manual on the other hand.
 
 I remind you how to enter the Nix environment: `source ~/.nix-profile/etc/profile.d/nix.sh`
 
@@ -211,7 +211,7 @@ Explaining:
 
 - In `test.nix` we return a function. It accepts a set, with default attributes `b`, `trueMsg` and `falseMsg`.
 
-- `builtins.trace` is a [built-in function](https://nixos.org/manual/nix/stable/expressions/builtins.html) that takes two arguments. The first is the message to display, the second is the value to return. It's usually used for debugging purposes.
+- `builtins.trace` is a [built-in function](https://nix.dev/manual/nix/stable/language/builtins) that takes two arguments. The first is the message to display, the second is the value to return. It's usually used for debugging purposes.
 
 - Then we import `test.nix`, and call the function with that set.
 

--- a/pills/06-our-first-derivation.md
+++ b/pills/06-our-first-derivation.md
@@ -8,7 +8,7 @@ I remind you how to enter the Nix environment: `source ~/.nix-profile/etc/profil
 
 ## The derivation function
 
-The [derivation built-in function](https://nixos.org/manual/nix/stable/expressions/derivations.html) is used to create derivations. I invite you to read the link in the Nix manual about the derivation built-in. A derivation from a Nix language view point is simply a set, with some attributes. Therefore you can pass the derivation around with variables like anything else.
+The [derivation built-in function](https://nix.dev/manual/nix/stable/language/derivations) is used to create derivations. I invite you to read the link in the Nix manual about the derivation built-in. A derivation from a Nix language view point is simply a set, with some attributes. Therefore you can pass the derivation around with variables like anything else.
 
 That's where the real power comes in.
 
@@ -291,9 +291,9 @@ Nix does not build derivations **during evaluation** of Nix expressions. In fact
 
 An important separation is made in Nix:
 
-- **Instantiate/Evaluation time**: the Nix expression is parsed, interpreted and finally returns a derivation set. During evaluation, you can refer to other derivations because Nix will create .drv files and we will know out paths beforehand. This is achieved with [nix-instantiate](https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html).
+- **Instantiate/Evaluation time**: the Nix expression is parsed, interpreted and finally returns a derivation set. During evaluation, you can refer to other derivations because Nix will create .drv files and we will know out paths beforehand. This is achieved with [nix-instantiate](https://nix.dev/manual/nix/stable/command-ref/nix-instantiate).
 
-- **Realise/Build time**: the .drv from the derivation set is built, first building .drv inputs (build dependencies). This is achieved with [nix-store -r](https://nixos.org/manual/nix/stable/command-ref/nix-store.html#operation---realise).
+- **Realise/Build time**: the .drv from the derivation set is built, first building .drv inputs (build dependencies). This is achieved with [nix-store -r](https://nix.dev/manual/nix/stable/command-ref/nix-store/realise).
 
 Think of it as of compile time and link time like with C/C++ projects. You first compile all source files to object files. Then link object files in a single executable.
 

--- a/pills/07-working-derivation.md
+++ b/pills/07-working-derivation.md
@@ -86,7 +86,7 @@ Let's inspect those environment variables printed during the build process.
 
 - `$PATH` plays the same game as `$HOME`
 
-- `$NIX_BUILD_CORES` and `$NIX_STORE` are [nix configuration options](https://nixos.org/manual/nix/stable/command-ref/conf-file.html)
+- `$NIX_BUILD_CORES` and `$NIX_STORE` are [nix configuration options](https://nix.dev/manual/nix/stable/command-ref/conf-file)
 
 - `$PWD` and `$TMP` clearly show that nix created a temporary build directory
 
@@ -204,9 +204,9 @@ Now you can build it with `nix-build simple.nix`. This will create a symlink `re
 
 nix-build does two jobs:
 
-- [ nix-instantiate ](https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html): parse and evaluate `simple.nix` and return the .drv file corresponding to the parsed derivation set
+- [nix-instantiate](https://nix.dev/manual/nix/stable/command-ref/nix-instantiate): parse and evaluate `simple.nix` and return the .drv file corresponding to the parsed derivation set
 
-- [ `nix-store -r` ](https://nixos.org/manual/nix/stable/command-ref/nix-store.html#operation---realise): realise the .drv file, which actually builds it.
+- [`nix-store -r`](https://nix.dev/manual/nix/stable/command-ref/nix-store/realise): realise the .drv file, which actually builds it.
 
 Finally, it creates the symlink.
 
@@ -232,7 +232,7 @@ derivation {
 }
 ```
 
-Here we also take the opportunity to introduce the [`inherit` keyword](https://nixos.org/manual/nix/stable/expressions/language-constructs.html#inheriting-attributes). `inherit foo;` is equivalent to `foo = foo;`. Similarly, `inherit gcc coreutils;` is equivalent to `gcc = gcc; coreutils = coreutils;`. Lastly, `inherit (pkgs) gcc coreutils;` is equivalent to `gcc = pkgs.gcc; coreutils = pkgs.coreutils;`.
+Here we also take the opportunity to introduce the [`inherit` keyword](https://nix.dev/manual/nix/stable/language/constructs#inheriting-attributes). `inherit foo;` is equivalent to `foo = foo;`. Similarly, `inherit gcc coreutils;` is equivalent to `gcc = gcc; coreutils = coreutils;`. Lastly, `inherit (pkgs) gcc coreutils;` is equivalent to `gcc = pkgs.gcc; coreutils = pkgs.coreutils;`.
 
 This syntax only makes sense inside sets. There's no magic involved, it's simply a convenience to avoid repeating the same name for both the attribute name and the value in scope.
 

--- a/pills/08-generic-builders.md
+++ b/pills/08-generic-builders.md
@@ -217,7 +217,7 @@ The body of the function is simple, yet at first sight it might be hard to grasp
 
 3.  Finally we create the derivation with that strange expression, (`defaultAttrs // attrs`).
 
-The [// operator](https://nixos.org/manual/nix/stable/expressions/language-operators.html) is an operator between two sets. The result is the union of the two sets. In case of conflicts between attribute names, the value on the right set is preferred.
+The [// operator](https://nix.dev/manual/nix/stable/language/operators.html#update) is an operator between two sets. The result is the union of the two sets. In case of conflicts between attribute names, the value on the right set is preferred.
 
 So we use `defaultAttrs` as base set, and add (or override) the attributes from `attrs`.
 

--- a/pills/10-developing-with-nix-shell.md
+++ b/pills/10-developing-with-nix-shell.md
@@ -8,7 +8,7 @@ Finally, we will modify our builder to work more ergonomically with a `nix-shell
 
 ## What is `nix-shell`?
 
-The [nix-shell](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html) tool drops us in a shell after setting up the environment variables necessary to hack on a derivation. It does not build the derivation; it only serves as a preparation so that we can run the build steps manually.
+The [nix-shell](https://nix.dev/manual/nix/stable/command-ref/nix-shell) tool drops us in a shell after setting up the environment variables necessary to hack on a derivation. It does not build the derivation; it only serves as a preparation so that we can run the build steps manually.
 
 Recall that in a nix environment, we don't have access to libraries or programs unless they have been installed with `nix-env`. However, installing libraries with `nix-env` is not good practice. We prefer to have isolated environments for development, which `nix-shell` provides for us.
 

--- a/pills/11-garbage-collector.md
+++ b/pills/11-garbage-collector.md
@@ -8,7 +8,7 @@ Today, we will stop focusing on packaging and instead look at a critical compone
 
 Programming languages with garbage collectors use the concept of a set of "garbage collector (or 'GC') roots" to keep track of "live" objects. A GC root is an object that is always considered "live" (unless explicitly removed as GC root). The garbage collection process starts from the GC roots and proceeds by recursively marking object references as "live". All other objects can be collected and deleted.
 
-Instead of objects, Nix's garbage collection operates on store paths, [with the GC roots themselves being store paths](https://nixos.org/manual/nix/stable/package-management/garbage-collector-roots.html). . This approach is much more principled than traditional package managers such as `dpkg` or `rpm`, which may leave around unused packages or dangling files.
+Instead of objects, Nix's garbage collection operates on store paths, [with the GC roots themselves being store paths](https://nix.dev/manual/nix/stable/package-management/garbage-collector-roots). . This approach is much more principled than traditional package managers such as `dpkg` or `rpm`, which may leave around unused packages or dangling files.
 
 The implementation is very simple and transparent to the user. The primary GC roots are stored under `/nix/var/nix/gcroots`. If there is a symlink to a store path, then the linked store path is a GC root.
 
@@ -18,7 +18,7 @@ In summary, Nix maintains a list of GC roots. These roots can then be used to co
 
 ## Playing with the GC
 
-Before we begin we first run the [nix garbage collector](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage.html) so that we have a clean setup for our experiments:
+Before we begin we first run the [nix garbage collector](https://nix.dev/manual/nix/stable/command-ref/nix-collect-garbage) so that we have a clean setup for our experiments:
 
 ```console
 $ nix-collect-garbage

--- a/pills/13-callpackage-design-pattern.md
+++ b/pills/13-callpackage-design-pattern.md
@@ -163,7 +163,7 @@ The reader should notice a magic thing happening. We're defining `pkgs` in terms
 
 The "`callPackage`" pattern has simplified our repository considerably. We were able to import packages that require named arguments and call them automatically, given the set of all packages sourced from `nixpkgs`.
 
-We've also introduced some useful builtin functions that allows us to introspect Nix functions and manipulate attributes. These builtin functions are not usually used when packaging software, but rather act as tools for packaging. They are documented in the [Nix manual](https://nixos.org/manual/nix/stable/expressions/builtins.html).
+We've also introduced some useful builtin functions that allows us to introspect Nix functions and manipulate attributes. These builtin functions are not usually used when packaging software, but rather act as tools for packaging. They are documented in the [Nix manual](https://nix.dev/manual/nix/stable/language/builtins).
 
 Writing a repository in Nix is an evolution of writing convenient functions for combining the packages. This pill demonstrates how Nix can be a generic tool to build and deploy software, and how suitable it is to create software repositories with our own conventions.
 

--- a/pills/15-nix-search-paths.md
+++ b/pills/15-nix-search-paths.md
@@ -6,7 +6,7 @@ Assuming you followed the previous posts, I hope you are now ready to understand
 
 ## The NIX_PATH
 
-The [NIX_PATH environment variable](https://nixos.org/manual/nix/stable/command-ref/env-common.html) is very important. It's very similar to the `PATH` environment variable. The syntax is similar, several paths are separated by a colon `:`. Nix will then search for something in those paths from left to right.
+The [NIX_PATH environment variable](https://nix.dev/manual/nix/stable/command-ref/env-common?highlight=NIX_PATH) is very important. It's very similar to the `PATH` environment variable. The syntax is similar, several paths are separated by a colon `:`. Nix will then search for something in those paths from left to right.
 
 Who uses `NIX_PATH`? The nix expressions! Yes, `NIX_PATH` is not of much use by the nix tools themselves, rather it's used when writing nix expressions.
 
@@ -16,7 +16,7 @@ In nix it's exactly the same, however the syntax is different. Instead of just t
 
 What's `NIX_PATH` good for? Nix expressions may refer to an "abstract" path such as `<nixpkgs>`, and it's possible to override it from the command line.
 
-For ease we will use `nix-instantiate --eval` to do our tests. I remind you, [nix-instantiate](https://nixos.org/manual/nix/stable/command-ref/nix-instantiate.html) is used to evaluate nix expressions and generate the .drv files. Here we are not interested in building derivations, so evaluation is enough. It can be used for one-shot expressions.
+For ease we will use `nix-instantiate --eval` to do our tests. I remind you, [nix-instantiate](https://nix.dev/manual/nix/stable/command-ref/nix-instantiate) is used to evaluate nix expressions and generate the .drv files. Here we are not interested in building derivations, so evaluation is enough. It can be used for one-shot expressions.
 
 ## Fake it a little
 
@@ -59,7 +59,7 @@ You may have a different path, depending on how you added channels etc.. Anyway 
 
 You can list that directory and realize it's simply a checkout of the nixpkgs repository at a specific commit (hint: `.version-suffix`).
 
-The `NIX_PATH` variable is exported by `nix.sh`, and that's the reason why I always asked you to [source nix.sh](https://nixos.org/manual/nix/stable/installation/env-variables.html) at the beginning of my posts.
+The `NIX_PATH` variable is exported by `nix.sh`, and that's the reason why I always asked you to [source nix.sh](https://nix.dev/manual/nix/stable/installation/env-variables) at the beginning of my posts.
 
 You may wonder: then I can also specify a different [nixpkgs](https://github.com/NixOS/nixpkgs) path to, e.g., a `git checkout` of `nixpkgs`? Yes, you can and I encourage doing that. We'll talk about this in the next pill.
 
@@ -75,7 +75,7 @@ Yes, `nix-build` also accepts paths with angular brackets. We first evaluate the
 
 ## A big word about nix-env
 
-The [nix-env](https://nixos.org/manual/nix/stable/command-ref/nix-env.html) command is a little different than `nix-instantiate` and `nix-build`. Whereas `nix-instantiate` and `nix-build` require a starting nix expression, `nix-env` does not.
+The [nix-env](https://nix.dev/manual/nix/stable/command-ref/nix-env) command is a little different than `nix-instantiate` and `nix-build`. Whereas `nix-instantiate` and `nix-build` require a starting nix expression, `nix-env` does not.
 
 You may be crippled by this concept at the beginning, you may think `nix-env` uses `NIX_PATH` to find the `nixpkgs` repository. But that's not it.
 

--- a/pills/18-nix-store-paths.md
+++ b/pills/18-nix-store-paths.md
@@ -122,7 +122,7 @@ In other words, you get a final .drv where every other .drv path is replaced by 
 
 Finally, the other most used kind of path is when we know beforehand an integrity hash of a file. This is usual for tarballs.
 
-A derivation can take three special attributes: `outputHashMode`, `outputHash` and `outputHashAlgo` which are well documented in the [nix manual](https://nixos.org/manual/nix/stable/expressions/advanced-attributes.html).
+A derivation can take three special attributes: `outputHashMode`, `outputHash` and `outputHashAlgo` which are well documented in the [nix manual](https://nix.dev/manual/nix/stable/language/advanced-attributes).
 
 The builder must create the out path and make sure its hash is the same as the one declared with `outputHash`.
 


### PR DESCRIPTION
This patch fixes some issues with links to the Nix manual.

Fixes:

- Broken links are replaced with working ones to equivalent pages
- Replace old manual domain (nixos.org) with nix.dev to avoid to be redirected