### PR TITLE
Generic builder needs to use baseInputs also

### DIFF
--- a/pills/08-generic-builders.md
+++ b/pills/08-generic-builders.md
@@ -91,7 +91,7 @@ Let's create a generic `builder.sh` for autotools projects:
 ```sh
 set -e
 unset PATH
-for p in $buildInputs; do
+for p in $baseInputs $buildInputs; do
     export PATH=$p/bin${PATH:+:}$PATH
 done
 


### PR DESCRIPTION
The generic builder only use buildInputs, but the autotools.nix defines baseInputs so the generic builder needs to use both the final packages PATHS (first) and the autotools PATHS (last)