### PR TITLE
Fixed minor typo in pill 13

### DIFF
--- a/pills/13-callpackage-design-pattern.md
+++ b/pills/13-callpackage-design-pattern.md
@@ -15,7 +15,7 @@ However, as with usual programming languages, there is some duplication of work:
 ...
 ```
 
-we would likely want to bundle that package derivation into a repository via a an attribute set defined as something like:
+we would likely want to bundle that package derivation into a repository via an attribute set defined as something like:
 
 ```nix
 rec {

--- a/pills/13-callpackage-design-pattern.md
+++ b/pills/13-callpackage-design-pattern.md
@@ -15,7 +15,7 @@ However, as with usual programming languages, there is some duplication of work:
 ...
 ```
 
-we would likely want to bundle that package derivation into a repository via an attribute set defined as something like:
+We would likely want to bundle that package derivation into a repository via an attribute set defined as something like:
 
 ```nix
 rec {


### PR DESCRIPTION
Removed the 'a' from 
"we would likely want to bundle that package derivation into a repository via **_a_** an attribute set defined as something like:"