### PR TITLE
[Fix]: add missing stdio header

### DIFF
--- a/pills/07-working-derivation.md
+++ b/pills/07-working-derivation.md
@@ -141,6 +141,8 @@ Given that `builder.sh` is a plain file, it has no .drv associated with it. The 
 Start off by writing a simple C program called `simple.c`:
 
 ```c
+#include <stdio.h>
+
 void main() {
     puts("Simple!");
 }


### PR DESCRIPTION
My setup required the inclusion of the stdio headers. 

I have little experience with C, so that caught me first time. 

By the way, I also had to change the filename of my C script, since it seems that Nix caches the files after the first compilation and I haven't found how to easily refresh the cache with `nix repl`. So, It could be cool to also include this in the docs.